### PR TITLE
UIとビジネスロジックを分離する

### DIFF
--- a/lib/controllers/diary_session_controller.dart
+++ b/lib/controllers/diary_session_controller.dart
@@ -1,0 +1,359 @@
+import 'dart:collection';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import '../models/user_settings.dart';
+import '../services/auth_service.dart';
+import '../services/firestore_service.dart';
+import '../services/gemini_service.dart';
+
+// 質問フェーズを表す列挙型
+// fixed        : 設定ベースの固定質問（睡眠/食事/運動/勉強/recallAssist）
+// eventQuestions: 出来事の構造化質問（いつ/どこで/誰が/誰と/何をした/どうだった）
+// ai           : AIによる追加質問（1回）
+// addendum     : 追記事項の確認
+// custom       : ユーザー定義のカスタム質問
+// confirm      : 「これでいいですか？」の確認ステップ（ボタンUI）
+// done         : 全質問完了・日記生成待ち
+enum _Phase { fixed, eventQuestions, ai, addendum, custom, confirm, done }
+
+// 1つの質問を表すデータクラス
+// choices: nullのときはテキスト入力式
+// key: answersマップへの保存キー。nullのとき（導入文など）は回答を記録しない
+class _Question {
+  final String text;
+  final List<String>? choices;
+  final String? key;
+  const _Question(this.text, {this.choices, this.key});
+}
+
+// 日記セッションのビジネスロジックを管理するコントローラ
+// UIから切り離し、フェーズ遷移・AI呼び出し・Firestore保存の責務を担う
+class DiarySessionController extends ChangeNotifier {
+  late final GeminiService _gemini;
+  final AuthService _auth = AuthService();
+  final FirestoreService _firestore = FirestoreService();
+
+  String? _uid;
+  String? _today;
+  int _conversationOrder = 0;
+  final List<Map<String, String>> _messages = [];
+  String? _diary;
+  String? _existingDiary;
+  int _addendumStartIndex = 0;
+  bool _isLoading = false;
+  bool _diaryGenerated = false;
+  bool _showExistingDiaryChoice = false;
+  List<String>? _currentChoices;
+  String? _pendingKey;
+  final Map<String, String> _answers = {};
+  String? _lastError;
+
+  _Phase _phase = _Phase.fixed;
+  final Queue<_Question> _fixedQueue = Queue();
+  final Queue<_Question> _eventQueue = Queue();
+  final Queue<_Question> _customQueue = Queue();
+
+  // 出来事についての構造化された固定質問リスト（_eventQuestionKeysと順序を合わせること）
+  static const List<String> _eventQuestions = [
+    'それはいつの出来事ですか？',
+    'どこでありましたか？',
+    'その出来事の主な登場人物は誰ですか？',
+    '誰かと一緒でしたか？',
+    '具体的に何をしましたか？',
+    'どんな気分・感想でしたか？',
+  ];
+
+  // 各出来事質問に対応する answers マップのキー（_eventQuestionsと順序を合わせること）
+  static const List<String> _eventQuestionKeys = [
+    'event_when',
+    'event_where',
+    'event_who',
+    'event_with',
+    'event_what',
+    'event_how',
+  ];
+
+  // ── Public getters (UI が読み取る状態) ──────────────────────────
+
+  String? get uid => _uid;
+  bool get isLoading => _isLoading;
+  bool get diaryGenerated => _diaryGenerated;
+  bool get showExistingDiaryChoice => _showExistingDiaryChoice;
+  List<Map<String, String>> get messages => List.unmodifiable(_messages);
+  String? get diary => _diary;
+  String? get lastError => _lastError;
+  List<String>? get currentChoices =>
+      _currentChoices != null ? List.unmodifiable(_currentChoices!) : null;
+
+  // UI の表示条件を計算するプロパティ（UIにフェーズ詳細を漏らさない）
+  bool get showChoices {
+    final lastIsAI = _messages.isNotEmpty && _messages.last['role'] == 'ai';
+    return !_diaryGenerated &&
+        !_isLoading &&
+        lastIsAI &&
+        _currentChoices != null &&
+        _phase != _Phase.confirm &&
+        _phase != _Phase.done;
+  }
+
+  bool get showInput {
+    final lastIsAI = _messages.isNotEmpty && _messages.last['role'] == 'ai';
+    return !_diaryGenerated &&
+        !_isLoading &&
+        lastIsAI &&
+        _currentChoices == null &&
+        _phase != _Phase.confirm &&
+        _phase != _Phase.done;
+  }
+
+  bool get showConfirmButton => _phase == _Phase.confirm && !_isLoading;
+
+  // ── 初期化 ──────────────────────────────────────────────────────
+
+  DiarySessionController() {
+    final apiKey = dotenv.env['GEMINI_API_KEY'] ?? '';
+    _gemini = GeminiService(apiKey);
+  }
+
+  Future<void> initialize() async {
+    _isLoading = true;
+    notifyListeners();
+    try {
+      _uid = await _auth.signInAnonymously();
+      _today = DateTime.now().toIso8601String().split('T')[0];
+
+      final existingDiary = await _firestore.getTodayDiary(_uid!, _today!);
+      if (existingDiary != null) {
+        _conversationOrder = await _firestore.getMessageCount(_uid!, _today!);
+        const message = '今日の事件簿がすでにあります。どうしますか？';
+        await _firestore.saveMessage(
+            _uid!, _today!, 'ai', message, _conversationOrder++);
+        _existingDiary = existingDiary;
+        _messages.add({'role': 'ai', 'text': message});
+        _showExistingDiaryChoice = true;
+        return;
+      }
+
+      final settings = await _firestore.getUserSettings(_uid!);
+      _buildQueues(settings);
+      await _askNext();
+    } catch (e) {
+      _setError('初期化エラー: $e');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  // ── 既存日記の選択肢処理 ─────────────────────────────────────────
+
+  Future<void> handleExistingDiaryChoice(String choice) async {
+    await _firestore.saveMessage(
+        _uid!, _today!, 'user', choice, _conversationOrder++);
+    _showExistingDiaryChoice = false;
+    _messages.add({'role': 'user', 'text': choice});
+    notifyListeners();
+
+    if (choice == '日記を確認する') {
+      _diary = _existingDiary;
+      _diaryGenerated = true;
+      notifyListeners();
+      return;
+    }
+
+    // 追記する → インタビュー開始インデックスを記録してから質問フローを開始
+    _addendumStartIndex = _messages.length;
+    _isLoading = true;
+    notifyListeners();
+    try {
+      final settings = await _firestore.getUserSettings(_uid!);
+      _buildQueues(settings);
+      await _askNext();
+    } catch (e) {
+      _setError('初期化エラー: $e');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  // ── 質問キュー構築 ───────────────────────────────────────────────
+
+  void _buildQueues(UserSettings settings) {
+    if (settings.recallAssist) {
+      _fixedQueue.addAll([
+        const _Question('午前中は何をしていましたか？', key: 'morning'),
+        const _Question('午後は何をしていましたか？', key: 'afternoon'),
+        const _Question('夜は何をしていましたか？', key: 'evening'),
+      ]);
+    }
+    if (settings.recordSleep) {
+      _fixedQueue.add(const _Question(
+        '昨夜は何時間くらい眠れましたか？',
+        choices: ['4時間以下', '5時間', '6時間', '7時間', '8時間', '9時間以上'],
+        key: 'sleep',
+      ));
+    }
+    if (settings.recordFood) {
+      _fixedQueue.add(const _Question('今日食べたものを教えてください。', key: 'food'));
+    }
+    if (settings.recordExercise) {
+      _fixedQueue.add(const _Question(
+        '今日、筋トレをしましたか？',
+        choices: ['はい', 'いいえ'],
+        key: 'exercise',
+      ));
+    }
+    if (settings.recordStudy) {
+      _fixedQueue.add(const _Question('今日の勉強内容を教えてください。', key: 'study'));
+    }
+
+    _eventQueue.add(const _Question('記録したい出来事についてお聞きします。'));
+    for (var i = 0; i < _eventQuestions.length; i++) {
+      _eventQueue.add(_Question(_eventQuestions[i], key: _eventQuestionKeys[i]));
+    }
+
+    for (var i = 0; i < settings.customQuestions.length; i++) {
+      _customQueue.add(_Question(settings.customQuestions[i], key: 'custom_$i'));
+    }
+  }
+
+  // ── フェーズ管理 ─────────────────────────────────────────────────
+
+  Future<void> _askNext() async {
+    switch (_phase) {
+      case _Phase.fixed:
+        if (_fixedQueue.isNotEmpty) {
+          final q = _fixedQueue.removeFirst();
+          _postAiMessage(q.text, choices: q.choices, key: q.key);
+        } else {
+          _phase = _Phase.eventQuestions;
+          await _askNext();
+        }
+      case _Phase.eventQuestions:
+        if (_eventQueue.isNotEmpty) {
+          final q = _eventQueue.removeFirst();
+          _postAiMessage(q.text, choices: q.choices, key: q.key);
+        } else {
+          _phase = _Phase.ai;
+          await _askAiFollowUp();
+        }
+      case _Phase.addendum:
+        _postAiMessage('追記したいことはありますか？（なければ「なし」と入力してください）',
+            key: 'addendum');
+      case _Phase.custom:
+        if (_customQueue.isNotEmpty) {
+          final q = _customQueue.removeFirst();
+          _postAiMessage(q.text, choices: q.choices, key: q.key);
+        } else {
+          _phase = _Phase.confirm;
+          await _askNext();
+        }
+      case _Phase.ai:
+        break; // AIフェーズは _askAiFollowUp() で直接呼ぶため _askNext() では何もしない
+      case _Phase.confirm:
+        _postAiMessage('以上で質問は終わりです。この内容で日記を生成しますか？');
+      case _Phase.done:
+        break;
+    }
+  }
+
+  // Geminiを呼ばずにメッセージをAI発言としてリストとFirestoreに追加する
+  void _postAiMessage(String text, {List<String>? choices, String? key}) {
+    _firestore.saveMessage(_uid!, _today!, 'ai', text, _conversationOrder++);
+    _messages.add({'role': 'ai', 'text': text});
+    _currentChoices = choices;
+    _pendingKey = key;
+    notifyListeners();
+  }
+
+  // ユーザーの返答を受け取り、現在のフェーズに応じて次のアクションを決める
+  Future<void> sendUserReply(String text) async {
+    if (text.trim().isEmpty) return;
+
+    if (_pendingKey != null) {
+      _answers[_pendingKey!] = text;
+      _pendingKey = null;
+    }
+
+    _currentChoices = null;
+    await _firestore.saveMessage(
+        _uid!, _today!, 'user', text, _conversationOrder++);
+    _messages.add({'role': 'user', 'text': text});
+    notifyListeners();
+
+    switch (_phase) {
+      case _Phase.fixed:
+        await _askNext();
+      case _Phase.eventQuestions:
+        await _askNext();
+      case _Phase.ai:
+        _phase = _Phase.addendum;
+        await _askNext();
+      case _Phase.addendum:
+        _phase = _Phase.custom;
+        await _askNext();
+      case _Phase.custom:
+        await _askNext();
+      case _Phase.confirm:
+        break; // confirmフェーズはボタンで操作するため入力は無視
+      case _Phase.done:
+        break;
+    }
+  }
+
+  // Geminiに追加質問を生成させる（AIフェーズで1回呼ばれる）
+  Future<void> _askAiFollowUp() async {
+    _isLoading = true;
+    notifyListeners();
+    try {
+      final followUp = await _gemini.generateFollowUp(_messages);
+      await _firestore.saveMessage(
+          _uid!, _today!, 'ai', followUp, _conversationOrder++);
+      _messages.add({'role': 'ai', 'text': followUp});
+      _pendingKey = 'ai_followup';
+      notifyListeners();
+    } catch (e) {
+      _setError('AIエラー: $e');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  // 会話履歴全体からGeminiに日記を生成させてFirestoreに保存する
+  Future<void> generateDiary() async {
+    _phase = _Phase.done;
+    _isLoading = true;
+    notifyListeners();
+    try {
+      final diary = _existingDiary != null
+          ? await _gemini.generateDiaryWithExisting(
+              _existingDiary!, _messages.sublist(_addendumStartIndex))
+          : await _gemini.generateDiary(_messages);
+      await Future.wait([
+        _firestore.saveDiary(_uid!, _today!, diary),
+        _firestore.saveAnswers(_uid!, _today!, _answers),
+      ]);
+      _diary = diary;
+      _diaryGenerated = true;
+      notifyListeners();
+    } catch (e) {
+      _setError('日記生成エラー: $e');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  // ── エラー ───────────────────────────────────────────────────────
+
+  void _setError(String message) {
+    _lastError = message;
+    notifyListeners();
+  }
+
+  void clearError() {
+    _lastError = null;
+  }
+}

--- a/lib/pages/diary_page.dart
+++ b/lib/pages/diary_page.dart
@@ -1,37 +1,12 @@
-import 'dart:collection';
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
+import '../controllers/diary_session_controller.dart';
 import '../core/theme/detective_theme.dart';
-import '../models/user_settings.dart';
-import '../services/auth_service.dart';
-import '../services/firestore_service.dart';
-import '../services/gemini_service.dart';
 import '../widgets/message_bubble.dart';
 import '../widgets/diary_card.dart';
 import '../widgets/input_area.dart';
 import 'diary_list_page.dart';
 
-// 質問フェーズを表す列挙型
-// fixed        : 設定ベースの固定質問（睡眠/食事/運動/勉強/recallAssist）
-// eventQuestions: 出来事の構造化質問（いつ/どこで/誰が/誰と/何をした/どうだった）
-// ai           : AIによる追加質問（1回）
-// addendum     : 追記事項の確認
-// custom       : ユーザー定義のカスタム質問
-// confirm      : 「これでいいですか？」の確認ステップ（ボタンUI）
-// done         : 全質問完了・日記生成待ち
-enum _Phase { fixed, eventQuestions, ai, addendum, custom, confirm, done }
-
-// 1つの質問を表すデータクラス
-// choices: nullのときはテキスト入力式
-// key: answersマップへの保存キー。nullのとき（導入文など）は回答を記録しない
-class _Question {
-  final String text;
-  final List<String>? choices;
-  final String? key;
-  const _Question(this.text, {this.choices, this.key});
-}
-
-// 今日の日記を作成するページ。AIとの対話を通じて日記を生成する
+// 今日の日記を作成するページ。ビジネスロジックは DiarySessionController に委譲する
 class DiaryPage extends StatefulWidget {
   const DiaryPage({super.key});
 
@@ -40,311 +15,36 @@ class DiaryPage extends StatefulWidget {
 }
 
 class _DiaryPageState extends State<DiaryPage> {
-  String? _uid;
-  String? _today; // 今日の日付（YYYY-MM-DD形式）
-  int _conversationOrder = 0; // Firestoreに保存するメッセージの順序カウンター
-  final List<Map<String, String>> _messages = []; // 画面に表示する会話履歴
-  String? _diary; // 生成された日記テキスト
-  String? _existingDiary; // 既存の日記テキスト（追記時に使用）
-  int _addendumStartIndex = 0; // 追記インタビュー開始時点の_messagesインデックス
-  bool _isLoading = false;
-  bool _diaryGenerated = false;
-  bool _showExistingDiaryChoice = false; // 追記 or 確認の選択肢を表示するフラグ
+  late final DiarySessionController _controller;
   final TextEditingController _textController = TextEditingController();
-  List<String>? _currentChoices; // 現在表示中の選択肢。nullのときはテキスト入力を表示
-  String? _pendingKey; // 直前のAI質問のキー（次のユーザー回答をanswersに紐づけるため）
-  final Map<String, String> _answers = {}; // 質問キー → 回答テキストのマップ
-
-  late final GeminiService _gemini;
-  final AuthService _auth = AuthService();
-  final FirestoreService _firestore = FirestoreService();
-
-  _Phase _phase = _Phase.fixed;
-  final Queue<_Question> _fixedQueue = Queue(); // 設定から生成した固定質問のキュー
-  final Queue<_Question> _eventQueue = Queue(); // 出来事の構造化質問のキュー
-  final Queue<_Question> _customQueue = Queue(); // ユーザー定義のカスタム質問のキュー
-
-  // 出来事についての構造化された固定質問リスト（_eventQuestionKeysと順序を合わせること）
-  static const List<String> _eventQuestions = [
-    'それはいつの出来事ですか？',
-    'どこでありましたか？',
-    'その出来事の主な登場人物は誰ですか？',
-    '誰かと一緒でしたか？',
-    '具体的に何をしましたか？',
-    'どんな気分・感想でしたか？',
-  ];
-
-  // 各出来事質問に対応する answers マップのキー（_eventQuestionsと順序を合わせること）
-  static const List<String> _eventQuestionKeys = [
-    'event_when',
-    'event_where',
-    'event_who',
-    'event_with',
-    'event_what',
-    'event_how',
-  ];
 
   @override
   void initState() {
     super.initState();
-    final apiKey = dotenv.env['GEMINI_API_KEY'] ?? '';
-    _gemini = GeminiService(apiKey);
-    _initSession();
+    _controller = DiarySessionController();
+    _controller.addListener(_onControllerUpdate);
+    _controller.initialize();
   }
 
   @override
   void dispose() {
+    _controller.removeListener(_onControllerUpdate);
+    _controller.dispose();
     _textController.dispose();
     super.dispose();
   }
 
-  // セッションを初期化する。今日の日記が既にあれば表示し、なければ質問を開始する
-  Future<void> _initSession() async {
-    setState(() => _isLoading = true);
-    try {
-      _uid = await _auth.signInAnonymously();
-      _today = DateTime.now().toIso8601String().split('T')[0];
-
-      final existingDiary = await _firestore.getTodayDiary(_uid!, _today!);
-      if (existingDiary != null) {
-        _conversationOrder = await _firestore.getMessageCount(_uid!, _today!);
-        const message = '今日の事件簿がすでにあります。どうしますか？';
-        await _firestore.saveMessage(
-            _uid!, _today!, 'ai', message, _conversationOrder++);
-        setState(() {
-          _existingDiary = existingDiary;
-          _messages.add({'role': 'ai', 'text': message});
-          _showExistingDiaryChoice = true;
-        });
-        return;
-      }
-
-      final settings = await _firestore.getUserSettings(_uid!);
-      _buildQueues(settings);
-      await _askNext();
-    } catch (e) {
-      _showError('初期化エラー: $e');
-    } finally {
-      setState(() => _isLoading = false);
-    }
-  }
-
-  // 既存の日記がある場合の選択肢（追記 or 確認）を処理する
-  Future<void> _handleExistingDiaryChoice(String choice) async {
-    await _firestore.saveMessage(
-        _uid!, _today!, 'user', choice, _conversationOrder++);
-    setState(() {
-      _showExistingDiaryChoice = false;
-      _messages.add({'role': 'user', 'text': choice});
-    });
-
-    if (choice == '日記を確認する') {
-      setState(() {
-        _diary = _existingDiary;
-        _diaryGenerated = true;
-      });
-      return;
-    }
-
-    // 追記する → インタビュー開始インデックスを記録してから質問フローを開始
-    _addendumStartIndex = _messages.length;
-    setState(() => _isLoading = true);
-    try {
-      final settings = await _firestore.getUserSettings(_uid!);
-      _buildQueues(settings);
-      await _askNext();
-    } catch (e) {
-      _showError('初期化エラー: $e');
-    } finally {
-      setState(() => _isLoading = false);
-    }
-  }
-
-  // ユーザー設定を元に固定質問キューとカスタム質問キューを構築する
-  void _buildQueues(UserSettings settings) {
-    if (settings.recallAssist) {
-      // 思い出しアシストONの場合、時間帯別の質問を3問追加する
-      _fixedQueue.addAll([
-        const _Question('午前中は何をしていましたか？', key: 'morning'),
-        const _Question('午後は何をしていましたか？', key: 'afternoon'),
-        const _Question('夜は何をしていましたか？', key: 'evening'),
-      ]);
-    }
-    if (settings.recordSleep) {
-      // 睡眠時間は数字選択式
-      _fixedQueue.add(const _Question(
-        '昨夜は何時間くらい眠れましたか？',
-        choices: ['4時間以下', '5時間', '6時間', '7時間', '8時間', '9時間以上'],
-        key: 'sleep',
-      ));
-    }
-    if (settings.recordFood) {
-      _fixedQueue.add(const _Question('今日食べたものを教えてください。', key: 'food'));
-    }
-    if (settings.recordExercise) {
-      // 筋トレの有無はYes/No選択式
-      _fixedQueue.add(const _Question(
-        '今日、筋トレをしましたか？',
-        choices: ['はい', 'いいえ'],
-        key: 'exercise',
-      ));
-    }
-    if (settings.recordStudy) {
-      _fixedQueue.add(const _Question('今日の勉強内容を教えてください。', key: 'study'));
-    }
-
-    // 冒頭の導入文はkeyなし（ユーザーの回答を伴わないため）
-    _eventQueue.add(const _Question('記録したい出来事についてお聞きします。'));
-    for (var i = 0; i < _eventQuestions.length; i++) {
-      _eventQueue.add(_Question(_eventQuestions[i], key: _eventQuestionKeys[i]));
-    }
-
-    for (var i = 0; i < settings.customQuestions.length; i++) {
-      _customQueue.add(_Question(settings.customQuestions[i], key: 'custom_$i'));
-    }
-  }
-
-  // 現在のフェーズに応じて次の質問をする
-  Future<void> _askNext() async {
-    switch (_phase) {
-      case _Phase.fixed:
-        if (_fixedQueue.isNotEmpty) {
-          final q = _fixedQueue.removeFirst();
-          _postAiMessage(q.text, choices: q.choices, key: q.key);
-        } else {
-          _phase = _Phase.eventQuestions;
-          await _askNext();
-        }
-      case _Phase.eventQuestions:
-        if (_eventQueue.isNotEmpty) {
-          final q = _eventQueue.removeFirst();
-          _postAiMessage(q.text, choices: q.choices, key: q.key);
-        } else {
-          // 構造化質問が終わったらAIの追加質問フェーズへ
-          _phase = _Phase.ai;
-          await _askAiFollowUp();
-        }
-      case _Phase.addendum:
-        _postAiMessage('追記したいことはありますか？（なければ「なし」と入力してください）',
-            key: 'addendum');
-      case _Phase.custom:
-        if (_customQueue.isNotEmpty) {
-          final q = _customQueue.removeFirst();
-          _postAiMessage(q.text, choices: q.choices, key: q.key);
-        } else {
-          _phase = _Phase.confirm;
-          await _askNext();
-        }
-      case _Phase.ai:
-        break; // AIフェーズは _askAiFollowUp() で直接呼ぶため_askNext()では何もしない
-      case _Phase.confirm:
-        // 確認ステップはボタンUIで表示するためメッセージだけ投稿する
-        _postAiMessage('以上で質問は終わりです。この内容で日記を生成しますか？');
-        setState(() {});
-      case _Phase.done:
-        break;
-    }
-  }
-
-  // Geminiを呼ばずにメッセージをAI発言としてリストとFirestoreに追加する
-  // choices: 指定された場合は選択肢ボタンを表示
-  // key: 次のユーザー回答をanswersマップに記録する際のキー
-  void _postAiMessage(String text, {List<String>? choices, String? key}) {
-    _firestore.saveMessage(_uid!, _today!, 'ai', text, _conversationOrder++);
-    setState(() {
-      _messages.add({'role': 'ai', 'text': text});
-      _currentChoices = choices;
-      _pendingKey = key;
-    });
-  }
-
-  // ユーザーの返答を受け取り、現在のフェーズに応じて次のアクションを決める
-  Future<void> _sendUserReply(String text) async {
-    if (text.trim().isEmpty) return;
-    _textController.clear();
-    setState(() => _currentChoices = null); // 選択肢を閉じる
-
-    // 直前の質問にキーがあれば回答をanswersマップに記録する
-    if (_pendingKey != null) {
-      _answers[_pendingKey!] = text;
-      _pendingKey = null;
-    }
-
-    await _firestore.saveMessage(
-        _uid!, _today!, 'user', text, _conversationOrder++);
-    setState(() => _messages.add({'role': 'user', 'text': text}));
-
-    switch (_phase) {
-      case _Phase.fixed:
-        await _askNext();
-      case _Phase.eventQuestions:
-        // 冒頭の「記録したい出来事について〜」はユーザー返答不要なのでスキップ済み
-        // 各構造化質問への回答後、次の質問へ進む
-        await _askNext();
-      case _Phase.ai:
-        // AI追加質問への返答後は追記フェーズへ
-        _phase = _Phase.addendum;
-        await _askNext();
-      case _Phase.addendum:
-        // 追記後はカスタム質問フェーズへ
-        _phase = _Phase.custom;
-        await _askNext();
-      case _Phase.custom:
-        await _askNext();
-      case _Phase.confirm:
-        break; // confirmフェーズはボタンで操作するため入力は無視
-      case _Phase.done:
-        break;
-    }
-  }
-
-  // Geminiに追加質問を生成させる（AIフェーズで1回呼ばれる）
-  Future<void> _askAiFollowUp() async {
-    setState(() => _isLoading = true);
-    try {
-      final followUp = await _gemini.generateFollowUp(_messages);
-      await _firestore.saveMessage(
-          _uid!, _today!, 'ai', followUp, _conversationOrder++);
-      setState(() {
-        _messages.add({'role': 'ai', 'text': followUp});
-        _pendingKey = 'ai_followup';
-      });
-    } catch (e) {
-      _showError('AIエラー: $e');
-    } finally {
-      setState(() => _isLoading = false);
-    }
-  }
-
-  // 会話履歴全体からGeminiに日記を生成させてFirestoreに保存する
-  Future<void> _generateDiary() async {
-    setState(() {
-      _phase = _Phase.done;
-      _isLoading = true;
-    });
-    try {
-      final diary = _existingDiary != null
-          ? await _gemini.generateDiaryWithExisting(
-              _existingDiary!, _messages.sublist(_addendumStartIndex))
-          : await _gemini.generateDiary(_messages);
-      await Future.wait([
-        _firestore.saveDiary(_uid!, _today!, diary),
-        _firestore.saveAnswers(_uid!, _today!, _answers),
-      ]);
-      setState(() {
-        _diary = diary;
-        _diaryGenerated = true;
-      });
-    } catch (e) {
-      _showError('日記生成エラー: $e');
-    } finally {
-      setState(() => _isLoading = false);
-    }
-  }
-
-  // エラーダイアログを表示する
-  void _showError(String message) {
+  // コントローラの状態変化を受けてUIを再描画し、エラーがあればダイアログを表示する
+  void _onControllerUpdate() {
     if (!mounted) return;
+    if (_controller.lastError != null) {
+      _showError(_controller.lastError!);
+      _controller.clearError();
+    }
+    setState(() {});
+  }
+
+  void _showError(String message) {
     showDialog(
       context: context,
       builder: (_) => AlertDialog(
@@ -361,27 +61,10 @@ class _DiaryPageState extends State<DiaryPage> {
 
   @override
   Widget build(BuildContext context) {
-    final lastIsAI = _messages.isNotEmpty && _messages.last['role'] == 'ai';
-    final showChoices = !_diaryGenerated &&
-        !_isLoading &&
-        lastIsAI &&
-        _currentChoices != null &&
-        _phase != _Phase.confirm &&
-        _phase != _Phase.done;
-    // confirmフェーズ・選択肢表示中はテキスト入力を非表示にする
-    final showInput = !_diaryGenerated &&
-        !_isLoading &&
-        lastIsAI &&
-        _currentChoices == null &&
-        _phase != _Phase.confirm &&
-        _phase != _Phase.done;
-    final showConfirmButton = _phase == _Phase.confirm && !_isLoading;
-
     return Scaffold(
       backgroundColor: DetectiveTheme.background,
 
       // ── AppBar ──────────────────────────────────────────────
-      // 設定ページ・ホームと同じくサブタイトル付きで捜査中の雰囲気を演出する
       appBar: AppBar(
         backgroundColor: DetectiveTheme.appBarBg,
         foregroundColor: const Color(0xFFE8DCC8),
@@ -402,11 +85,11 @@ class _DiaryPageState extends State<DiaryPage> {
             icon: const Icon(Icons.folder_open),
             tooltip: '事件簿アーカイブ',
             onPressed: () {
-              if (_uid == null) return;
+              if (_controller.uid == null) return;
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (_) => DiaryListPage(uid: _uid!),
+                  builder: (_) => DiaryListPage(uid: _controller.uid!),
                 ),
               );
             },
@@ -418,25 +101,26 @@ class _DiaryPageState extends State<DiaryPage> {
           Expanded(
             child: ListView.builder(
               padding: const EdgeInsets.all(16),
-              itemCount: _messages.length + (_diary != null ? 1 : 0),
+              itemCount: _controller.messages.length +
+                  (_controller.diary != null ? 1 : 0),
               itemBuilder: (context, index) {
                 // 末尾に生成された日記カードを表示する
-                if (_diary != null && index == _messages.length) {
-                  return DiaryCard(diary: _diary!);
+                if (_controller.diary != null &&
+                    index == _controller.messages.length) {
+                  return DiaryCard(diary: _controller.diary!);
                 }
-                final msg = _messages[index];
+                final msg = _controller.messages[index];
                 return MessageBubble(role: msg['role']!, text: msg['text']!);
               },
             ),
           ),
-          if (_isLoading)
+          if (_controller.isLoading)
             const Padding(
               padding: EdgeInsets.all(12.0),
-              // ゴールドのローディングインジケーターでテーマに統一する
               child: CircularProgressIndicator(color: DetectiveTheme.gold),
             ),
           // 追記 or 確認の選択肢ボタン
-          if (_showExistingDiaryChoice && !_isLoading)
+          if (_controller.showExistingDiaryChoice && !_controller.isLoading)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
               child: Row(
@@ -445,7 +129,8 @@ class _DiaryPageState extends State<DiaryPage> {
                     child: Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 4),
                       child: ElevatedButton(
-                        onPressed: () => _handleExistingDiaryChoice(choice),
+                        onPressed: () =>
+                            _controller.handleExistingDiaryChoice(choice),
                         style: ElevatedButton.styleFrom(
                           backgroundColor: const Color(0xFF5C3D2E),
                           foregroundColor: Colors.white,
@@ -462,15 +147,15 @@ class _DiaryPageState extends State<DiaryPage> {
               ),
             ),
           // 選択肢ボタン群
-          if (!_showExistingDiaryChoice && showChoices)
+          if (!_controller.showExistingDiaryChoice && _controller.showChoices)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
               child: Wrap(
                 spacing: 8,
                 runSpacing: 8,
-                children: _currentChoices!.map((choice) {
+                children: _controller.currentChoices!.map((choice) {
                   return ElevatedButton(
-                    onPressed: () => _sendUserReply(choice),
+                    onPressed: () => _controller.sendUserReply(choice),
                     style: ElevatedButton.styleFrom(
                       backgroundColor: DetectiveTheme.gold,
                       foregroundColor: Colors.white,
@@ -484,13 +169,13 @@ class _DiaryPageState extends State<DiaryPage> {
               ),
             ),
           // 「これでいいですか？」確認ボタン
-          if (showConfirmButton)
+          if (_controller.showConfirmButton)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
               child: SizedBox(
                 width: double.infinity,
                 child: ElevatedButton(
-                  onPressed: _generateDiary,
+                  onPressed: _controller.generateDiary,
                   style: ElevatedButton.styleFrom(
                     backgroundColor: DetectiveTheme.gold,
                     foregroundColor: Colors.white,
@@ -507,8 +192,14 @@ class _DiaryPageState extends State<DiaryPage> {
                 ),
               ),
             ),
-          if (!_showExistingDiaryChoice && showInput)
-            InputArea(controller: _textController, onSubmit: _sendUserReply),
+          if (!_controller.showExistingDiaryChoice && _controller.showInput)
+            InputArea(
+              controller: _textController,
+              onSubmit: (text) {
+                _textController.clear();
+                _controller.sendUserReply(text);
+              },
+            ),
         ],
       ),
     );


### PR DESCRIPTION
#51 
# なぜ改善したか
DiaryPage の _DiaryPageState（516行）が以下の責務をすべて1クラスで担っており、凝集度が低い状態だった。

・認証・セッション初期化
・質問フェーズの遷移管理
・質問キューの構築
・Gemini AI の呼び出し
・Firestore へのデータ保存
・UI の描画

この状態は「良いコードとは何か」で解説される時間的凝集（アプリ起動時にまとめて動くものが集まっているだけ）に該当し、変更箇所が UI / ロジック / データ層に跨るため保守性・可読性ともに低かった。
また、UIクラスが直接 FirestoreService や GeminiService に依存しており、Clean Architecture で重要とされる「依存の方向は内側（ビジネスロジック）に向かうべき」というルールに反していた。

# やった事
lib/controllers/diary_session_controller.dart を新規作成

ChangeNotifier を継承した ViewModel クラスとして、_DiaryPageState からビジネスロジックをすべて抽出した。


状態変化は notifyListeners() で通知し、diary_page.dart 側は addListener で受け取って setState を呼ぶ構造にした。エラー処理は lastError プロパティ経由でUIに伝達し、ダイアログ表示（BuildContext が必要な処理）だけをページ側に残した。

lib/pages/diary_page.dart を大幅削減

516行 → 150行。ページの責務を以下のみに絞った。

DiarySessionController の生成・リスナー登録・破棄
エラーダイアログの表示
build() による UI 描画
