### PR TITLE
DBスキーマを再設計しUIを新APIに追従

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,1 +1,29 @@
-{"flutter":{"platforms":{"android":{"default":{"projectId":"nikki-next","appId":"1:623797177770:android:afcb11e66000dd1ecb2fd3","fileOutput":"android/app/google-services.json"}},"dart":{"lib/firebase_options.dart":{"projectId":"nikki-next","configurations":{"android":"1:623797177770:android:afcb11e66000dd1ecb2fd3","ios":"1:623797177770:ios:34016d5f71c8a4bccb2fd3","macos":"1:623797177770:ios:34016d5f71c8a4bccb2fd3","web":"1:623797177770:web:58d0c200e5340557cb2fd3","windows":"1:623797177770:web:5a85108c7f89cb36cb2fd3"}}}}}}
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "flutter": {
+    "platforms": {
+      "android": {
+        "default": {
+          "projectId": "nikki-next",
+          "appId": "1:623797177770:android:afcb11e66000dd1ecb2fd3",
+          "fileOutput": "android/app/google-services.json"
+        }
+      },
+      "dart": {
+        "lib/firebase_options.dart": {
+          "projectId": "nikki-next",
+          "configurations": {
+            "android": "1:623797177770:android:afcb11e66000dd1ecb2fd3",
+            "ios": "1:623797177770:ios:34016d5f71c8a4bccb2fd3",
+            "macos": "1:623797177770:ios:34016d5f71c8a4bccb2fd3",
+            "web": "1:623797177770:web:58d0c200e5340557cb2fd3",
+            "windows": "1:623797177770:web:5a85108c7f89cb36cb2fd3"
+          }
+        }
+      }
+    }
+  }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,76 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isSignedIn() {
+      return request.auth != null;
+    }
+    function isOwner(uid) {
+      return isSignedIn() && request.auth.uid == uid;
+    }
+    function isValidString(value, maxLen) {
+      return value is string && value.size() <= maxLen;
+    }
+
+    match /users/{uid} {
+      allow read: if isOwner(uid);
+
+      allow create: if isOwner(uid)
+        && request.resource.data.providerId in ['anonymous', 'google.com']
+        && request.resource.data.schemaVersion is int
+        && request.resource.data.createdAt == request.time;
+
+      allow update: if isOwner(uid)
+        && request.resource.data.providerId in ['anonymous', 'google.com']
+        && request.resource.data.createdAt == resource.data.createdAt
+        && request.resource.data.schemaVersion == resource.data.schemaVersion;
+
+      allow delete: if false;
+
+      match /settings/preferences {
+        allow read, write: if isOwner(uid);
+      }
+
+      match /customQuestions/{questionId} {
+        allow read: if isOwner(uid);
+        allow create: if isOwner(uid)
+          && isValidString(request.resource.data.text, 200)
+          && request.resource.data.type in ['text', 'number', 'single_choice']
+          && request.resource.data.enabled is bool
+          && request.resource.data.order is number;
+        allow update: if isOwner(uid)
+          && isValidString(request.resource.data.text, 200)
+          && request.resource.data.type in ['text', 'number', 'single_choice']
+          && request.resource.data.enabled is bool
+          && request.resource.data.order is number;
+        allow delete: if isOwner(uid);
+      }
+
+      match /days/{date} {
+        function isValidDate() {
+          return date.matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}$');
+        }
+
+        allow read: if isOwner(uid);
+        allow create, update: if isOwner(uid)
+          && isValidDate()
+          && (!('diary' in request.resource.data)
+              || request.resource.data.diary == null
+              || isValidString(request.resource.data.diary, 10000))
+          && (!('responses' in request.resource.data)
+              || request.resource.data.responses.size() <= 100);
+        allow delete: if isOwner(uid);
+
+        match /conversation/{messageId} {
+          allow read: if isOwner(uid);
+          allow create: if isOwner(uid)
+            && request.resource.data.role in ['ai', 'user']
+            && isValidString(request.resource.data.text, 5000)
+            && request.resource.data.order is int;
+          allow update, delete: if false;
+        }
+      }
+    }
+  }
+}

--- a/lib/models/app_user.dart
+++ b/lib/models/app_user.dart
@@ -1,0 +1,72 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+// users/{uid} 本体のプロフィール情報を保持するモデル
+// Google認証への移行を見据え、displayName / email / providerId を持つ
+class AppUser {
+  final String uid;
+  final String? displayName;
+  final String? email;
+  final String? photoUrl;
+  final String providerId; // "anonymous" または "google.com"
+  final DateTime? createdAt;
+  final DateTime? lastSignInAt;
+  final int schemaVersion; // 将来のマイグレーション識別用
+
+  const AppUser({
+    required this.uid,
+    this.displayName,
+    this.email,
+    this.photoUrl,
+    required this.providerId,
+    this.createdAt,
+    this.lastSignInAt,
+    this.schemaVersion = 1,
+  });
+
+  factory AppUser.fromMap(String uid, Map<String, dynamic> map) {
+    return AppUser(
+      uid: uid,
+      displayName: map['displayName'] as String?,
+      email: map['email'] as String?,
+      photoUrl: map['photoUrl'] as String?,
+      providerId: map['providerId'] as String? ?? 'anonymous',
+      createdAt: (map['createdAt'] as Timestamp?)?.toDate(),
+      lastSignInAt: (map['lastSignInAt'] as Timestamp?)?.toDate(),
+      schemaVersion: map['schemaVersion'] as int? ?? 1,
+    );
+  }
+
+  // Firestore書き込み用マップ
+  // createdAt / lastSignInAt は呼び出し側（FirestoreService）が
+  // FieldValue.serverTimestamp() で別途付与する
+  Map<String, dynamic> toMap() {
+    return {
+      'displayName': displayName,
+      'email': email,
+      'photoUrl': photoUrl,
+      'providerId': providerId,
+      'schemaVersion': schemaVersion,
+    };
+  }
+
+  AppUser copyWith({
+    String? displayName,
+    String? email,
+    String? photoUrl,
+    String? providerId,
+    DateTime? createdAt,
+    DateTime? lastSignInAt,
+    int? schemaVersion,
+  }) {
+    return AppUser(
+      uid: uid,
+      displayName: displayName ?? this.displayName,
+      email: email ?? this.email,
+      photoUrl: photoUrl ?? this.photoUrl,
+      providerId: providerId ?? this.providerId,
+      createdAt: createdAt ?? this.createdAt,
+      lastSignInAt: lastSignInAt ?? this.lastSignInAt,
+      schemaVersion: schemaVersion ?? this.schemaVersion,
+    );
+  }
+}

--- a/lib/models/custom_question.dart
+++ b/lib/models/custom_question.dart
@@ -1,0 +1,118 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+// 質問の入力タイプ
+enum QuestionType {
+  text, // 自由テキスト
+  number, // 数値入力（睡眠時間など）
+  singleChoice; // 選択肢から1つ選ぶ
+
+  String get value {
+    switch (this) {
+      case QuestionType.text:
+        return 'text';
+      case QuestionType.number:
+        return 'number';
+      case QuestionType.singleChoice:
+        return 'single_choice';
+    }
+  }
+
+  static QuestionType fromValue(String? v) {
+    switch (v) {
+      case 'text':
+        return QuestionType.text;
+      case 'number':
+        return QuestionType.number;
+      case 'single_choice':
+        return QuestionType.singleChoice;
+      default:
+        return QuestionType.text;
+    }
+  }
+}
+
+// users/{uid}/customQuestions/{questionId} のモデル
+// ユーザーが自由に追加する質問。順序・有効化・論理削除をサポートする
+class CustomQuestion {
+  final String id;
+  final String text;
+  final QuestionType type;
+  final List<String>? choices; // type=singleChoice のとき必須
+  final String? unit; // type=number のとき "時間", "kg" など
+  final bool enabled; // 一時無効化用（archivedAt とは別）
+  final double order; // 並び順。double で中間値挿入を可能にする
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final DateTime? archivedAt; // 論理削除フラグ（過去日記からの参照を壊さない）
+
+  const CustomQuestion({
+    required this.id,
+    required this.text,
+    this.type = QuestionType.text,
+    this.choices,
+    this.unit,
+    this.enabled = true,
+    this.order = 0,
+    this.createdAt,
+    this.updatedAt,
+    this.archivedAt,
+  });
+
+  // 新規記録に使える状態か（archived でなく かつ enabled）
+  bool get isActive => archivedAt == null && enabled;
+
+  factory CustomQuestion.fromMap(String id, Map<String, dynamic> map) {
+    final rawChoices = map['choices'];
+    return CustomQuestion(
+      id: id,
+      text: map['text'] as String? ?? '',
+      type: QuestionType.fromValue(map['type'] as String?),
+      choices: rawChoices is List ? rawChoices.cast<String>() : null,
+      unit: map['unit'] as String?,
+      enabled: map['enabled'] as bool? ?? true,
+      order: (map['order'] as num?)?.toDouble() ?? 0.0,
+      createdAt: (map['createdAt'] as Timestamp?)?.toDate(),
+      updatedAt: (map['updatedAt'] as Timestamp?)?.toDate(),
+      archivedAt: (map['archivedAt'] as Timestamp?)?.toDate(),
+    );
+  }
+
+  // Firestore書き込み用マップ
+  // createdAt / updatedAt / archivedAt は FirestoreService が
+  // FieldValue.serverTimestamp() / null で別途付与する
+  Map<String, dynamic> toMap() {
+    return {
+      'text': text,
+      'type': type.value,
+      'choices': choices,
+      'unit': unit,
+      'enabled': enabled,
+      'order': order,
+    };
+  }
+
+  CustomQuestion copyWith({
+    String? text,
+    QuestionType? type,
+    List<String>? choices,
+    String? unit,
+    bool? enabled,
+    double? order,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    DateTime? archivedAt,
+  }) {
+    return CustomQuestion(
+      id: id,
+      text: text ?? this.text,
+      type: type ?? this.type,
+      choices: choices ?? this.choices,
+      unit: unit ?? this.unit,
+      enabled: enabled ?? this.enabled,
+      order: order ?? this.order,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      archivedAt: archivedAt ?? this.archivedAt,
+    );
+  }
+}

--- a/lib/models/day_entry.dart
+++ b/lib/models/day_entry.dart
@@ -1,0 +1,128 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'response_entry.dart';
+
+// 日記の生成元
+enum DiarySource {
+  ai, // AI生成
+  manual, // ユーザー手入力
+  aiThenEdited; // AI生成後にユーザーが編集
+
+  String get value {
+    switch (this) {
+      case DiarySource.ai:
+        return 'ai';
+      case DiarySource.manual:
+        return 'manual';
+      case DiarySource.aiThenEdited:
+        return 'ai_then_edited';
+    }
+  }
+
+  static DiarySource fromValue(String? v) {
+    switch (v) {
+      case 'ai':
+        return DiarySource.ai;
+      case 'manual':
+        return DiarySource.manual;
+      case 'ai_then_edited':
+        return DiarySource.aiThenEdited;
+      default:
+        return DiarySource.ai;
+    }
+  }
+}
+
+// users/{uid}/days/{YYYY-MM-DD} のモデル
+// 1日分の日記テキスト・質問回答・数値メトリクスを保持する
+class DayEntry {
+  final String date; // ドキュメントID（YYYY-MM-DD）
+  final String? diary; // AI生成または手入力の日記テキスト
+  final DiarySource? diarySource;
+  final List<ResponseEntry> responses;
+  // 数値質問だけ抽出した冗長コピー。analytics の O(1) アクセス用
+  // 保存時に FirestoreService が responses から自動生成する
+  final Map<String, double> metrics;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  const DayEntry({
+    required this.date,
+    this.diary,
+    this.diarySource,
+    this.responses = const [],
+    this.metrics = const {},
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  // 指定 questionKey に対応する回答テキストを返す（なければnull）
+  // analytics_page などで頻繁に使う lookup を簡潔にするためのヘルパー
+  String? answerTextFor(String questionKey) {
+    for (final r in responses) {
+      if (r.questionKey == questionKey) return r.answerText;
+    }
+    return null;
+  }
+
+  factory DayEntry.fromMap(String date, Map<String, dynamic> map) {
+    final rawResponses = map['responses'];
+    final responses = rawResponses is List
+        ? rawResponses
+            .whereType<Map>()
+            .map((m) => ResponseEntry.fromMap(m.cast<String, dynamic>()))
+            .toList()
+        : <ResponseEntry>[];
+
+    final rawMetrics = map['metrics'];
+    final metrics = <String, double>{};
+    if (rawMetrics is Map) {
+      rawMetrics.forEach((key, value) {
+        if (key is String && value is num) {
+          metrics[key] = value.toDouble();
+        }
+      });
+    }
+
+    return DayEntry(
+      date: date,
+      diary: map['diary'] as String?,
+      diarySource: map['diarySource'] != null
+          ? DiarySource.fromValue(map['diarySource'] as String?)
+          : null,
+      responses: responses,
+      metrics: metrics,
+      createdAt: (map['createdAt'] as Timestamp?)?.toDate(),
+      updatedAt: (map['updatedAt'] as Timestamp?)?.toDate(),
+    );
+  }
+
+  // Firestore書き込み用マップ
+  // createdAt / updatedAt は FirestoreService が serverTimestamp で別途付与する
+  Map<String, dynamic> toMap() {
+    return {
+      'diary': diary,
+      'diarySource': diarySource?.value,
+      'responses': responses.map((r) => r.toMap()).toList(),
+      'metrics': metrics,
+    };
+  }
+
+  DayEntry copyWith({
+    String? diary,
+    DiarySource? diarySource,
+    List<ResponseEntry>? responses,
+    Map<String, double>? metrics,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return DayEntry(
+      date: date,
+      diary: diary ?? this.diary,
+      diarySource: diarySource ?? this.diarySource,
+      responses: responses ?? this.responses,
+      metrics: metrics ?? this.metrics,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+}

--- a/lib/models/response_entry.dart
+++ b/lib/models/response_entry.dart
@@ -1,0 +1,133 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'custom_question.dart';
+
+// 回答の出所（どこから来た質問か）
+// プレフィックス命名規則（"custom_*", "event_*"）に代わる正式な分類
+enum ResponseSource {
+  appFixed, // 設定ベースの固定質問（sleep / food / exercise / study）
+  appEvent, // 出来事の構造化質問（event_when / where / who / what / how）
+  appRecall, // 思い出しアシスト（morning / afternoon / evening）
+  userCustom, // ユーザー定義のカスタム質問
+  aiFollowUp, // AIによる深掘り質問
+  addendum; // 追記事項
+
+  String get value {
+    switch (this) {
+      case ResponseSource.appFixed:
+        return 'app_fixed';
+      case ResponseSource.appEvent:
+        return 'app_event';
+      case ResponseSource.appRecall:
+        return 'app_recall';
+      case ResponseSource.userCustom:
+        return 'user_custom';
+      case ResponseSource.aiFollowUp:
+        return 'ai_followup';
+      case ResponseSource.addendum:
+        return 'addendum';
+    }
+  }
+
+  static ResponseSource fromValue(String? v) {
+    switch (v) {
+      case 'app_fixed':
+        return ResponseSource.appFixed;
+      case 'app_event':
+        return ResponseSource.appEvent;
+      case 'app_recall':
+        return ResponseSource.appRecall;
+      case 'user_custom':
+        return ResponseSource.userCustom;
+      case 'ai_followup':
+        return ResponseSource.aiFollowUp;
+      case 'addendum':
+        return ResponseSource.addendum;
+      default:
+        return ResponseSource.appFixed;
+    }
+  }
+}
+
+// days/{date}.responses[] の要素モデル
+// 1つの質問と回答のペアを保持する
+class ResponseEntry {
+  final ResponseSource source;
+  final String questionKey; // "sleep" / "event_when" / "custom_<questionId>" など
+  final DocumentReference? questionRef; // source=userCustom のとき customQuestions/{id} 参照
+  final String questionText; // 質問文のスナップショット（編集後も元の文言を保持）
+  final QuestionType questionType;
+  final String? answerText;
+  final double? answerNumber;
+  final int? answerChoiceIndex; // 選択肢回答のインデックス（自由記述併用ケース追跡用）
+  final bool includedInDiary; // AI日記生成に含めた回答か
+  final int order;
+
+  const ResponseEntry({
+    required this.source,
+    required this.questionKey,
+    this.questionRef,
+    required this.questionText,
+    this.questionType = QuestionType.text,
+    this.answerText,
+    this.answerNumber,
+    this.answerChoiceIndex,
+    this.includedInDiary = true,
+    required this.order,
+  });
+
+  factory ResponseEntry.fromMap(Map<String, dynamic> map) {
+    return ResponseEntry(
+      source: ResponseSource.fromValue(map['source'] as String?),
+      questionKey: map['questionKey'] as String? ?? '',
+      questionRef: map['questionRef'] as DocumentReference?,
+      questionText: map['questionText'] as String? ?? '',
+      questionType: QuestionType.fromValue(map['questionType'] as String?),
+      answerText: map['answerText'] as String?,
+      answerNumber: (map['answerNumber'] as num?)?.toDouble(),
+      answerChoiceIndex: map['answerChoiceIndex'] as int?,
+      includedInDiary: map['includedInDiary'] as bool? ?? true,
+      order: map['order'] as int? ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'source': source.value,
+      'questionKey': questionKey,
+      'questionRef': questionRef,
+      'questionText': questionText,
+      'questionType': questionType.value,
+      'answerText': answerText,
+      'answerNumber': answerNumber,
+      'answerChoiceIndex': answerChoiceIndex,
+      'includedInDiary': includedInDiary,
+      'order': order,
+    };
+  }
+
+  ResponseEntry copyWith({
+    ResponseSource? source,
+    String? questionKey,
+    DocumentReference? questionRef,
+    String? questionText,
+    QuestionType? questionType,
+    String? answerText,
+    double? answerNumber,
+    int? answerChoiceIndex,
+    bool? includedInDiary,
+    int? order,
+  }) {
+    return ResponseEntry(
+      source: source ?? this.source,
+      questionKey: questionKey ?? this.questionKey,
+      questionRef: questionRef ?? this.questionRef,
+      questionText: questionText ?? this.questionText,
+      questionType: questionType ?? this.questionType,
+      answerText: answerText ?? this.answerText,
+      answerNumber: answerNumber ?? this.answerNumber,
+      answerChoiceIndex: answerChoiceIndex ?? this.answerChoiceIndex,
+      includedInDiary: includedInDiary ?? this.includedInDiary,
+      order: order ?? this.order,
+    );
+  }
+}

--- a/lib/models/user_settings.dart
+++ b/lib/models/user_settings.dart
@@ -1,4 +1,8 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 // ユーザーの記録設定を保持するモデル
+// customQuestions は独立サブコレクション users/{uid}/customQuestions/{id} に移行したため
+// このモデルからは除外している
 class UserSettings {
   final bool recordEvent; // 今日の印象的な出来事を記録するか（デフォルトON）
   final bool recallAssist; // 午前・午後・夜の時間帯別質問を追加するか
@@ -6,10 +10,10 @@ class UserSettings {
   final bool recordFood; // 食事内容を記録するか
   final bool recordExercise; // 運動習慣を記録するか
   final bool recordStudy; // 勉強内容を記録するか
-  final List<String> customQuestions; // ユーザーが自由に追加したカスタム質問リスト
   final bool notificationEnabled; // 毎日リマインダー通知を送るか
   final int notificationHour; // 通知時刻：時（0–23）
   final int notificationMinute; // 通知時刻：分（0–59）
+  final DateTime? updatedAt; // 最終更新時刻（FirestoreService が serverTimestamp で更新）
 
   const UserSettings({
     this.recordEvent = true,
@@ -18,10 +22,10 @@ class UserSettings {
     this.recordFood = false,
     this.recordExercise = false,
     this.recordStudy = false,
-    this.customQuestions = const [],
     this.notificationEnabled = false,
     this.notificationHour = 21,
     this.notificationMinute = 0,
+    this.updatedAt,
   });
 
   // デフォルト設定を返すファクトリ
@@ -36,15 +40,15 @@ class UserSettings {
       recordFood: map['recordFood'] as bool? ?? false,
       recordExercise: map['recordExercise'] as bool? ?? false,
       recordStudy: map['recordStudy'] as bool? ?? false,
-      customQuestions:
-          (map['customQuestions'] as List<dynamic>?)?.cast<String>() ?? [],
       notificationEnabled: map['notificationEnabled'] as bool? ?? false,
       notificationHour: map['notificationHour'] as int? ?? 21,
       notificationMinute: map['notificationMinute'] as int? ?? 0,
+      updatedAt: (map['updatedAt'] as Timestamp?)?.toDate(),
     );
   }
 
-  // FirestoreへのマップにシリアライズするメソッドFirestoreへ保存する際に使用
+  // Firestore書き込み用マップ
+  // updatedAt は FirestoreService が FieldValue.serverTimestamp() で別途付与する
   Map<String, dynamic> toMap() {
     return {
       'recordEvent': recordEvent,
@@ -53,7 +57,6 @@ class UserSettings {
       'recordFood': recordFood,
       'recordExercise': recordExercise,
       'recordStudy': recordStudy,
-      'customQuestions': customQuestions,
       'notificationEnabled': notificationEnabled,
       'notificationHour': notificationHour,
       'notificationMinute': notificationMinute,
@@ -68,10 +71,10 @@ class UserSettings {
     bool? recordFood,
     bool? recordExercise,
     bool? recordStudy,
-    List<String>? customQuestions,
     bool? notificationEnabled,
     int? notificationHour,
     int? notificationMinute,
+    DateTime? updatedAt,
   }) {
     return UserSettings(
       recordEvent: recordEvent ?? this.recordEvent,
@@ -80,10 +83,10 @@ class UserSettings {
       recordFood: recordFood ?? this.recordFood,
       recordExercise: recordExercise ?? this.recordExercise,
       recordStudy: recordStudy ?? this.recordStudy,
-      customQuestions: customQuestions ?? this.customQuestions,
       notificationEnabled: notificationEnabled ?? this.notificationEnabled,
       notificationHour: notificationHour ?? this.notificationHour,
       notificationMinute: notificationMinute ?? this.notificationMinute,
+      updatedAt: updatedAt ?? this.updatedAt,
     );
   }
 }

--- a/lib/pages/analytics_page.dart
+++ b/lib/pages/analytics_page.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 import '../core/theme/app_colors.dart';
 import '../core/theme/detective_text_styles.dart';
-import '../models/user_settings.dart';
+import '../models/custom_question.dart';
+import '../models/day_entry.dart';
 import '../services/auth_service.dart';
 import '../services/firestore_service.dart';
 
@@ -21,9 +22,9 @@ class _AnalyticsPageState extends State<AnalyticsPage> {
   bool _isLoading = true;
   // YYYY-MM-DD → 睡眠時間（記録なし日はnull）
   final Map<String, double?> _sleepData = {};
-  // YYYY-MM-DD → エントリ全データ
-  final Map<String, Map<String, dynamic>> _entriesData = {};
-  UserSettings? _settings;
+  // YYYY-MM-DD → DayEntry
+  final Map<String, DayEntry> _entriesData = {};
+  List<CustomQuestion> _customQuestions = [];
 
   static const int _days = 14;
 
@@ -41,26 +42,23 @@ class _AnalyticsPageState extends State<AnalyticsPage> {
         return;
       }
 
-      // 並行フェッチ
-      final entriesFuture = _firestore.getRecentEntries(uid, _days);
-      final settingsFuture = _firestore.getUserSettings(uid);
-      final entries = await entriesFuture;
-      final settings = await settingsFuture;
+      // 並行フェッチ（days と customQuestions を同時に取得）
+      final daysFuture = _firestore.getRecentDays(uid, _days);
+      final questionsFuture = _firestore.getActiveCustomQuestions(uid);
+      final days = await daysFuture;
+      final customQuestions = await questionsFuture;
 
       final sleepData = <String, double?>{};
-      final entriesData = <String, Map<String, dynamic>>{};
-      for (final entry in entries) {
-        entriesData[entry.key] = entry.value;
-        final numeric =
-            entry.value['numericAnswers'] as Map<String, dynamic>?;
-        final sleep = numeric?['sleep'];
-        sleepData[entry.key] = sleep != null ? (sleep as num).toDouble() : null;
+      final entriesData = <String, DayEntry>{};
+      for (final day in days) {
+        entriesData[day.date] = day;
+        sleepData[day.date] = day.metrics['sleep'];
       }
 
       setState(() {
         _sleepData.addAll(sleepData);
         _entriesData.addAll(entriesData);
-        _settings = settings;
+        _customQuestions = customQuestions;
         _isLoading = false;
       });
     } catch (_) {
@@ -116,7 +114,7 @@ class _AnalyticsPageState extends State<AnalyticsPage> {
                   _RecordsTable(
                     dates: dates.reversed.toList(), // 新しい順
                     entriesData: _entriesData,
-                    customQuestions: _settings?.customQuestions ?? [],
+                    customQuestions: _customQuestions,
                   ),
                 ],
               ),
@@ -271,8 +269,8 @@ class _SleepChart extends StatelessWidget {
 class _RecordsTable extends StatelessWidget {
   // dates は新しい順（降順）
   final List<String> dates;
-  final Map<String, Map<String, dynamic>> entriesData;
-  final List<String> customQuestions;
+  final Map<String, DayEntry> entriesData;
+  final List<CustomQuestion> customQuestions;
 
   const _RecordsTable({
     required this.dates,
@@ -290,11 +288,8 @@ class _RecordsTable extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = context.colors;
-    final customHeaders = customQuestions
-        .asMap()
-        .entries
-        .map((e) => _truncate(e.value, 10))
-        .toList();
+    final customHeaders =
+        customQuestions.map((q) => _truncate(q.text, 10)).toList();
     final allHeaders = [..._fixedHeaders, ...customHeaders];
 
     return Container(
@@ -327,8 +322,7 @@ class _RecordsTable extends StatelessWidget {
               .map((h) => DataColumn(label: Text(h)))
               .toList(),
           rows: dates.map((date) {
-            final answers = entriesData[date]?['answers']
-                as Map<String, dynamic>?;
+            final day = entriesData[date];
             final parts = date.split('-');
             final dateLabel = '${parts[1]}/${parts[2]}';
 
@@ -339,16 +333,14 @@ class _RecordsTable extends StatelessWidget {
                       color: c.textPrimary,
                       fontSize: 12))),
               ..._fixedKeys.map((key) {
-                final val = answers?[key] as String?;
+                final val = day?.answerTextFor(key);
                 return DataCell(_TableCell(value: val));
               }),
             ];
 
-            final customCells = customQuestions
-                .asMap()
-                .entries
-                .map((e) {
-              final val = answers?['custom_${e.key}'] as String?;
+            final customCells = customQuestions.map((q) {
+              // 新スキーマでは custom 質問のキーは 'custom_<questionId>'
+              final val = day?.answerTextFor('custom_${q.id}');
               return DataCell(_TableCell(value: val));
             }).toList();
 

--- a/lib/pages/diary_edit_page.dart
+++ b/lib/pages/diary_edit_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../core/theme/app_colors.dart';
 import '../core/theme/detective_text_styles.dart';
+import '../models/day_entry.dart';
 import '../services/firestore_service.dart';
 import 'diary_list_page.dart';
 
@@ -46,7 +47,12 @@ class _DiaryEditPageState extends State<DiaryEditPage> {
     if (text.isEmpty) return;
     setState(() => _isSaving = true);
     try {
-      await widget.firestore.saveDiary(widget.uid, widget.today, text);
+      // initialDiary が null = 新規入力（manual）、非null = AI生成後の編集（ai_then_edited）
+      final source = widget.initialDiary == null
+          ? DiarySource.manual
+          : DiarySource.aiThenEdited;
+      await widget.firestore
+          .saveDiaryText(widget.uid, widget.today, text, source);
       setState(() => _saved = true);
     } catch (e) {
       if (mounted) {

--- a/lib/pages/diary_list_page.dart
+++ b/lib/pages/diary_list_page.dart
@@ -13,7 +13,7 @@ class DiaryListPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final entriesRef = FirestoreService().entriesQuery(uid);
+    final daysRef = FirestoreService().daysQuery(uid);
     final c = context.colors;
 
     return Scaffold(
@@ -41,7 +41,7 @@ class DiaryListPage extends StatelessWidget {
       // ── Body ────────────────────────────────────────────────
       // Firestoreのリアルタイム更新をStreamBuilderで受け取って一覧を描画する
       body: StreamBuilder<QuerySnapshot>(
-        stream: entriesRef.snapshots(),
+        stream: daysRef.snapshots(),
         builder: (context, snapshot) {
           // 読み込み中: ゴールドのローディングインジケーター
           if (snapshot.connectionState == ConnectionState.waiting) {

--- a/lib/pages/diary_page.dart
+++ b/lib/pages/diary_page.dart
@@ -1,8 +1,12 @@
 import 'dart:collection';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import '../core/theme/app_colors.dart';
 import '../core/theme/detective_text_styles.dart';
+import '../models/custom_question.dart';
+import '../models/day_entry.dart';
+import '../models/response_entry.dart';
 import '../models/user_settings.dart';
 import '../services/auth_service.dart';
 import '../services/firestore_service.dart';
@@ -37,11 +41,24 @@ enum _Phase {
 // 1つの質問を表すデータクラス
 // choices: nullのときはテキスト入力式
 // key: answersマップへの保存キー。nullのとき（導入文など）は回答を記録しない
+// source: 質問の出所（app_fixed / app_event / app_recall / user_custom / ai_followup / addendum）
+// questionType: 回答タイプ（保存時 ResponseEntry.questionType に転写）
+// questionRef: source=userCustom のときの customQuestions/{id} 参照
 class _Question {
   final String text;
   final List<String>? choices;
   final String? key;
-  const _Question(this.text, {this.choices, this.key});
+  final ResponseSource source;
+  final QuestionType questionType;
+  final DocumentReference<Map<String, dynamic>>? questionRef;
+  const _Question(
+    this.text, {
+    this.choices,
+    this.key,
+    this.source = ResponseSource.appFixed,
+    this.questionType = QuestionType.text,
+    this.questionRef,
+  });
 }
 
 // 今日の日記を作成するページ。AIとの対話を通じて日記を生成する
@@ -68,6 +85,10 @@ class _DiaryPageState extends State<DiaryPage> {
   String? _pendingKey; // 直前のAI質問のキー（次のユーザー回答をanswersに紐づけるため）
   final Map<String, String> _answers = {}; // 質問キー → 回答テキストのマップ
   final Map<String, double> _numericAnswers = {}; // 質問キー → 数値回答のマップ
+  // 質問キー → 質問メタ情報（source/text/type/ref）のマップ
+  // 保存時に ResponseEntry を組み立てるための質問文スナップショット保持
+  // 同じキーが再度問われた場合は上書きされる（最新のスナップショットを採用）
+  final Map<String, _Question> _askedQuestions = {};
 
   late final GeminiService _gemini;
   final AuthService _auth = AuthService();
@@ -90,25 +111,35 @@ class _DiaryPageState extends State<DiaryPage> {
       'それはいつの話だ？',
       choices: ['朝', '昼', '夜', '仕事中', '学校', 'プライベート', 'その他(自由記述)'],
       key: 'event_when',
+      source: ResponseSource.appEvent,
+      questionType: QuestionType.singleChoice,
     ),
     _Question(
       'どこで起きた？',
       choices: ['自宅', '学校', '職場', 'その他(自由記述)'],
       key: 'event_where',
+      source: ResponseSource.appEvent,
+      questionType: QuestionType.singleChoice,
     ),
     _Question(
       '誰に関わる話だ？',
       choices: ['自分', 'その他(自由記述)'],
       key: 'event_who',
+      source: ResponseSource.appEvent,
+      questionType: QuestionType.singleChoice,
     ),
     _Question(
       '何があった？話してくれ。',
       key: 'event_what',
+      source: ResponseSource.appEvent,
+      questionType: QuestionType.text,
     ),
     _Question(
       'そのとき、どう感じた？',
       choices: ['嬉しかった', '面白かった', '悲しかった', '怒った', 'その他(自由記述)'],
       key: 'event_how',
+      source: ResponseSource.appEvent,
+      questionType: QuestionType.singleChoice,
     ),
   ];
 
@@ -133,7 +164,7 @@ class _DiaryPageState extends State<DiaryPage> {
       _uid = await _auth.signInAnonymously();
       _today = DateTime.now().toIso8601String().split('T')[0];
 
-      final existingDiary = await _firestore.getTodayDiary(_uid!, _today!);
+      final existingDiary = await _firestore.getDayDiary(_uid!, _today!);
       if (existingDiary != null) {
         _conversationOrder = await _firestore.getMessageCount(_uid!, _today!);
         const message = '今日の事件簿はすでに存在する。どうするつもりだ？';
@@ -147,8 +178,15 @@ class _DiaryPageState extends State<DiaryPage> {
         return;
       }
 
-      final settings = await _firestore.getUserSettings(_uid!);
-      _buildQueues(settings);
+      // settings と customQuestions を並行フェッチして質問キューを構築
+      final results = await Future.wait([
+        _firestore.getUserSettings(_uid!),
+        _firestore.getActiveCustomQuestions(_uid!),
+      ]);
+      _buildQueues(
+        results[0] as UserSettings,
+        results[1] as List<CustomQuestion>,
+      );
       await _askNext();
     } catch (e) {
       _showError('初期化エラー: $e');
@@ -178,8 +216,14 @@ class _DiaryPageState extends State<DiaryPage> {
     // 追記する → 質問フローを開始
     setState(() => _isLoading = true);
     try {
-      final settings = await _firestore.getUserSettings(_uid!);
-      _buildQueues(settings);
+      final results = await Future.wait([
+        _firestore.getUserSettings(_uid!),
+        _firestore.getActiveCustomQuestions(_uid!),
+      ]);
+      _buildQueues(
+        results[0] as UserSettings,
+        results[1] as List<CustomQuestion>,
+      );
       await _askNext();
     } catch (e) {
       _showError('初期化エラー: $e');
@@ -188,9 +232,14 @@ class _DiaryPageState extends State<DiaryPage> {
     }
   }
 
-  // ユーザー設定を元に各質問キューを構築する
-  void _buildQueues(UserSettings settings) {
-    // ── カスタム質問キュー（sleep/food/exercise/study + ユーザー定義）──
+  // ユーザー設定とカスタム質問リストを元に各質問キューを構築する
+  // 各 _Question には source / questionType / questionRef を付与し、
+  // 保存時に ResponseEntry へ展開できるようにする
+  void _buildQueues(
+    UserSettings settings,
+    List<CustomQuestion> customQuestions,
+  ) {
+    // ── 固定質問キュー（sleep/food/exercise/study）──
     if (settings.recordSleep) {
       _customQueue.add(const _Question(
         '昨夜は何時間眠った？',
@@ -201,16 +250,25 @@ class _DiaryPageState extends State<DiaryPage> {
           '13時間〜', 'カスタム',
         ],
         key: 'sleep',
+        source: ResponseSource.appFixed,
+        questionType: QuestionType.singleChoice,
       ));
     }
     if (settings.recordFood) {
-      _customQueue.add(const _Question('今日、何を口にした？', key: 'food'));
+      _customQueue.add(const _Question(
+        '今日、何を口にした？',
+        key: 'food',
+        source: ResponseSource.appFixed,
+        questionType: QuestionType.text,
+      ));
     }
     if (settings.recordExercise) {
       _customQueue.add(const _Question(
         '身体を動かしたか？',
         choices: ['した', 'していない'],
         key: 'exercise',
+        source: ResponseSource.appFixed,
+        questionType: QuestionType.singleChoice,
       ));
     }
     if (settings.recordStudy) {
@@ -218,19 +276,47 @@ class _DiaryPageState extends State<DiaryPage> {
         '今日、頭を使う作業はしたか？',
         choices: ['した', 'していない'],
         key: 'study',
+        source: ResponseSource.appFixed,
+        questionType: QuestionType.singleChoice,
       ));
     }
-    for (var i = 0; i < settings.customQuestions.length; i++) {
-      _customQueue.add(_Question(settings.customQuestions[i], key: 'custom_$i'));
+
+    // ── ユーザー定義のカスタム質問 ──
+    // questionRef は customQuestions/{id} ドキュメント参照
+    // questionKey は 'custom_<questionId>' 形式（旧 custom_<index> から変更）
+    for (final cq in customQuestions) {
+      _customQueue.add(_Question(
+        cq.text,
+        choices: cq.choices,
+        key: 'custom_${cq.id}',
+        source: ResponseSource.userCustom,
+        questionType: cq.type,
+        questionRef: _firestore.customQuestionRef(_uid!, cq.id),
+      ));
     }
 
     // ── 思い出しアシストキュー ──
     _hasRecallAssist = settings.recallAssist;
     if (settings.recallAssist) {
       _recallQueue.addAll([
-        const _Question('午前中の動向を報告してくれ。', key: 'morning'),
-        const _Question('午後はどう動いた？', key: 'afternoon'),
-        const _Question('夜の動向は？', key: 'evening'),
+        const _Question(
+          '午前中の動向を報告してくれ。',
+          key: 'morning',
+          source: ResponseSource.appRecall,
+          questionType: QuestionType.text,
+        ),
+        const _Question(
+          '午後はどう動いた？',
+          key: 'afternoon',
+          source: ResponseSource.appRecall,
+          questionType: QuestionType.text,
+        ),
+        const _Question(
+          '夜の動向は？',
+          key: 'evening',
+          source: ResponseSource.appRecall,
+          questionType: QuestionType.text,
+        ),
       ]);
     }
 
@@ -260,7 +346,14 @@ class _DiaryPageState extends State<DiaryPage> {
         }
         if (_customQueue.isNotEmpty) {
           final q = _customQueue.removeFirst();
-          _postAiMessage(q.text, choices: q.choices, key: q.key);
+          _postAiMessage(
+            q.text,
+            choices: q.choices,
+            key: q.key,
+            source: q.source,
+            questionType: q.questionType,
+            questionRef: q.questionRef,
+          );
         } else {
           _phase = _Phase.customSaved;
           await _askNext();
@@ -291,7 +384,14 @@ class _DiaryPageState extends State<DiaryPage> {
         }
         if (_recallQueue.isNotEmpty) {
           final q = _recallQueue.removeFirst();
-          _postAiMessage(q.text, key: q.key);
+          _postAiMessage(
+            q.text,
+            choices: q.choices,
+            key: q.key,
+            source: q.source,
+            questionType: q.questionType,
+            questionRef: q.questionRef,
+          );
         } else {
           _phase = _Phase.recallSaved;
           await _askNext();
@@ -309,7 +409,14 @@ class _DiaryPageState extends State<DiaryPage> {
       case _Phase.event:
         if (_eventQueue.isNotEmpty) {
           final q = _eventQueue.removeFirst();
-          _postAiMessage(q.text, choices: q.choices, key: q.key);
+          _postAiMessage(
+            q.text,
+            choices: q.choices,
+            key: q.key,
+            source: q.source,
+            questionType: q.questionType,
+            questionRef: q.questionRef,
+          );
         } else {
           _phase = _Phase.aiFollowUp;
           await _askAiFollowUp();
@@ -331,12 +438,33 @@ class _DiaryPageState extends State<DiaryPage> {
   // Geminiを呼ばずにメッセージをAI発言としてリストとFirestoreに追加する
   // choices: 指定された場合は選択肢ボタンを表示
   // key: 次のユーザー回答をanswersマップに記録する際のキー
-  void _postAiMessage(String text, {List<String>? choices, String? key}) {
+  // source / questionType / questionRef: 保存時に ResponseEntry に転写するメタ情報
+  //   key が non-null の場合に _askedQuestions[key] にスナップショットを保存する
+  void _postAiMessage(
+    String text, {
+    List<String>? choices,
+    String? key,
+    ResponseSource source = ResponseSource.appFixed,
+    QuestionType questionType = QuestionType.text,
+    DocumentReference<Map<String, dynamic>>? questionRef,
+  }) {
     _firestore.saveMessage(_uid!, _today!, 'ai', text, _conversationOrder++);
     setState(() {
       _messages.add({'role': 'ai', 'text': text});
       _currentChoices = choices;
       _pendingKey = key;
+      if (key != null) {
+        // 質問文のスナップショットを残す。後でカスタム質問が編集/archiveされても
+        // 今回保存される responses[].questionText には元の文言が残る
+        _askedQuestions[key] = _Question(
+          text,
+          choices: choices,
+          key: key,
+          source: source,
+          questionType: questionType,
+          questionRef: questionRef,
+        );
+      }
     });
   }
 
@@ -414,8 +542,13 @@ class _DiaryPageState extends State<DiaryPage> {
         await _askNext();
       case _Phase.addendum:
         if (text == 'はい(追記事項の入力へ)') {
-          // 自由記述の追記入力へ（回答をaddendum_textキーで記録）
-          _postAiMessage('言い残したことを話してくれ。', key: 'addendum');
+          // 自由記述の追記入力へ（回答を addendum キーで記録）
+          _postAiMessage(
+            '言い残したことを話してくれ。',
+            key: 'addendum',
+            source: ResponseSource.addendum,
+            questionType: QuestionType.text,
+          );
         } else if (text == 'いいえ(日記の生成へ)') {
           // 追記なしで日記生成へ
           _phase = _Phase.diaryView;
@@ -444,12 +577,13 @@ class _DiaryPageState extends State<DiaryPage> {
         await _askNext();
         return;
       }
-      await _firestore.saveMessage(
-          _uid!, _today!, 'ai', followUp, _conversationOrder++);
-      setState(() {
-        _messages.add({'role': 'ai', 'text': followUp});
-        _pendingKey = 'ai_followup';
-      });
+      // _postAiMessage で質問メタも _askedQuestions に登録される
+      _postAiMessage(
+        followUp,
+        key: 'ai_followup',
+        source: ResponseSource.aiFollowUp,
+        questionType: QuestionType.text,
+      );
     } catch (e) {
       _showError('AIエラー: $e');
     } finally {
@@ -492,9 +626,12 @@ class _DiaryPageState extends State<DiaryPage> {
           _currentChoices = null;
           _phase = _Phase.event;
         });
-        // event関連の回答をクリアしてキューを再構築
-        _answers.removeWhere((k, _) =>
-            k.startsWith('event_') || k == 'ai_followup' || k == 'addendum');
+        // event関連の回答とメタをクリアしてキューを再構築
+        bool isEventRelated(String k) =>
+            k.startsWith('event_') || k == 'ai_followup' || k == 'addendum';
+        _answers.removeWhere((k, _) => isEventRelated(k));
+        _numericAnswers.removeWhere((k, _) => isEventRelated(k));
+        _askedQuestions.removeWhere((k, _) => isEventRelated(k));
         _eventQueue.clear();
         for (final q in _eventQuestions) {
           _eventQueue.add(q);
@@ -527,6 +664,7 @@ class _DiaryPageState extends State<DiaryPage> {
   }
 
   // 会話履歴からGeminiに日記を生成させてFirestoreに保存する
+  // 保存は saveDay() で一括（responses[] と metrics は同時にコミットされる）
   Future<void> _generateDiary() async {
     setState(() {
       _phase = _Phase.diaryView;
@@ -542,11 +680,17 @@ class _DiaryPageState extends State<DiaryPage> {
               additionalContext: additionalContext)
           : await _gemini.generateDiary(eventMessages,
               additionalContext: additionalContext);
-      await Future.wait([
-        _firestore.saveDiary(_uid!, _today!, diary),
-        _firestore.saveAnswers(_uid!, _today!, _answers,
-            numericAnswers: _numericAnswers),
-      ]);
+
+      // _answers / _numericAnswers / _askedQuestions から ResponseEntry を組み立て、
+      // DayEntry として一括保存。metrics は saveDay 内で responses から自動生成される
+      final day = DayEntry(
+        date: _today!,
+        diary: diary,
+        diarySource: DiarySource.ai,
+        responses: _buildResponses(),
+      );
+      await _firestore.saveDay(_uid!, day);
+
       _postAiMessage('事件簿を作成した。確認してくれ。');
       setState(() {
         _diary = diary;
@@ -556,6 +700,49 @@ class _DiaryPageState extends State<DiaryPage> {
       _showError('日記生成エラー: $e');
     } finally {
       setState(() => _isLoading = false);
+    }
+  }
+
+  // _answers / _numericAnswers / _askedQuestions を join して ResponseEntry のリストを構築
+  // - 各回答の source は _askedQuestions の質問メタから取得
+  // - includedInDiary は source と _include*InDiary フラグから決定
+  // - order は _answers の挿入順（LinkedHashMap）に合わせる
+  List<ResponseEntry> _buildResponses() {
+    final responses = <ResponseEntry>[];
+    var order = 0;
+    for (final entry in _answers.entries) {
+      final meta = _askedQuestions[entry.key];
+      if (meta == null) continue; // メタ未登録の回答は保存対象外（防御的）
+      responses.add(ResponseEntry(
+        source: meta.source,
+        questionKey: entry.key,
+        questionRef: meta.questionRef,
+        questionText: meta.text,
+        questionType: meta.questionType,
+        answerText: entry.value,
+        answerNumber: _numericAnswers[entry.key],
+        includedInDiary: _isIncludedInDiary(meta.source),
+        order: order++,
+      ));
+    }
+    return responses;
+  }
+
+  // 回答を AI 日記生成に含めるかを source から決定する
+  // appEvent / aiFollowUp / addendum は常に含める（出来事の本筋なので）
+  // appFixed / userCustom は _includeCustomInDiary
+  // appRecall は _includeRecallInDiary
+  bool _isIncludedInDiary(ResponseSource source) {
+    switch (source) {
+      case ResponseSource.appFixed:
+      case ResponseSource.userCustom:
+        return _includeCustomInDiary;
+      case ResponseSource.appRecall:
+        return _includeRecallInDiary;
+      case ResponseSource.appEvent:
+      case ResponseSource.aiFollowUp:
+      case ResponseSource.addendum:
+        return true;
     }
   }
 

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -7,6 +7,7 @@ import '../core/theme/app_colors.dart';
 import '../core/theme/app_theme.dart';
 import '../core/theme/detective_text_styles.dart';
 import '../core/theme/theme_controller.dart';
+import '../models/custom_question.dart';
 import '../models/user_settings.dart';
 import '../services/auth_service.dart';
 import '../services/firestore_service.dart';
@@ -23,6 +24,7 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   UserSettings _settings = UserSettings.defaults();
+  List<CustomQuestion> _customQuestions = []; // archivedAt==null のみ、order昇順
   String? _uid;
   bool _isLoading = true;
   bool _isSaving = false; // 保存中フラグ（AppBarにスピナーを表示するために使用）
@@ -46,14 +48,27 @@ class _SettingsPageState extends State<SettingsPage> {
     super.dispose();
   }
 
-  // FirestoreからUserSettingsを読み込む
+  // FirestoreからUserSettingsとcustomQuestionsを並行ロードする
   Future<void> _loadSettings() async {
     _uid = await _auth.signInAnonymously();
-    final settings = await _firestore.getUserSettings(_uid!);
+    final results = await Future.wait([
+      _firestore.getUserSettings(_uid!),
+      _firestore.getActiveCustomQuestions(_uid!),
+    ]);
     setState(() {
-      _settings = settings;
+      _settings = results[0] as UserSettings;
+      _customQuestions = results[1] as List<CustomQuestion>;
       _isLoading = false;
     });
+  }
+
+  // customQuestionsのみ再読み込みする（追加・削除後に呼ぶ）
+  Future<void> _reloadCustomQuestions() async {
+    if (_uid == null) return;
+    final list = await _firestore.getActiveCustomQuestions(_uid!);
+    if (mounted) {
+      setState(() => _customQuestions = list);
+    }
   }
 
   // 設定を更新してFirestoreに即時保存する（トグル操作のたびに呼ばれる）
@@ -97,14 +112,23 @@ class _SettingsPageState extends State<SettingsPage> {
     }
   }
 
-  // テキストフィールドの内容をカスタム質問リストに追加して保存する
-  void _addCustomQuestion() {
+  // テキストフィールドの内容をcustomQuestionsコレクションに追加する
+  // 既存リストの末尾に挿入するため order は現リスト+1.0
+  Future<void> _addCustomQuestion() async {
+    if (_uid == null) return;
     final text = _customQuestionController.text.trim();
     if (text.isEmpty) return;
     _customQuestionController.clear();
-    _save(_settings.copyWith(
-      customQuestions: [..._settings.customQuestions, text],
-    ));
+    final nextOrder = _customQuestions.isEmpty
+        ? 1.0
+        : _customQuestions.last.order + 1.0;
+    await _firestore.addCustomQuestion(
+      _uid!,
+      text: text,
+      type: QuestionType.text,
+      order: nextOrder,
+    );
+    await _reloadCustomQuestions();
   }
 
   // 全エントリをCSV形式に変換してシェアシートを開く
@@ -112,30 +136,33 @@ class _SettingsPageState extends State<SettingsPage> {
     if (_uid == null) return;
     setState(() => _isExporting = true);
     try {
-      final entries = await _firestore.getAllEntries(_uid!);
+      final days = await _firestore.getAllDays(_uid!);
 
-      // 全エントリに含まれるanswerキーを収集してCSVの列を決定する
-      final allAnswerKeys = <String>{};
-      for (final entry in entries) {
-        final answers = entry.value['answers'] as Map<String, dynamic>?;
-        if (answers != null) allAnswerKeys.addAll(answers.keys);
+      // 全 day を走査して questionKey → questionText を構築
+      // 同じキーで違う文言があれば走査順で後勝ち（archive 後の質問テキストも保持）
+      final keyToText = <String, String>{};
+      for (final day in days) {
+        for (final r in day.responses) {
+          keyToText[r.questionKey] = r.questionText;
+        }
       }
-      final answerKeys = allAnswerKeys.toList()..sort();
+      final sortedKeys = keyToText.keys.toList()..sort();
 
-      // ヘッダー行
+      // ヘッダー行（questionText を列名にしてCSVを読みやすくする）
       final rows = <List<String>>[
-        ['日付', '日記', ...answerKeys],
+        ['日付', '日記', ...sortedKeys.map((k) => keyToText[k] ?? k)],
       ];
 
       // データ行
-      for (final entry in entries) {
-        final date = entry.key;
-        final diary = (entry.value['diary'] as String?) ?? '';
-        final answers = (entry.value['answers'] as Map<String, dynamic>?) ?? {};
+      for (final day in days) {
+        final answers = <String, String>{};
+        for (final r in day.responses) {
+          if (r.answerText != null) answers[r.questionKey] = r.answerText!;
+        }
         rows.add([
-          date,
-          diary,
-          ...answerKeys.map((k) => (answers[k] as String?) ?? ''),
+          day.date,
+          day.diary ?? '',
+          ...sortedKeys.map((k) => answers[k] ?? ''),
         ]);
       }
 
@@ -178,11 +205,12 @@ class _SettingsPageState extends State<SettingsPage> {
     return value;
   }
 
-  // 指定インデックスのカスタム質問を削除して保存する
-  void _removeCustomQuestion(int index) {
-    final updated = List<String>.from(_settings.customQuestions)
-      ..removeAt(index);
-    _save(_settings.copyWith(customQuestions: updated));
+  // 指定IDのカスタム質問を論理削除する（archivedAtをセット）
+  // 過去日記からの questionRef 参照が壊れないように完全削除はしない
+  Future<void> _removeCustomQuestion(String questionId) async {
+    if (_uid == null) return;
+    await _firestore.archiveCustomQuestion(_uid!, questionId);
+    await _reloadCustomQuestions();
   }
 
   @override
@@ -301,34 +329,33 @@ class _SettingsPageState extends State<SettingsPage> {
                 _SettingsCard(
                   children: [
                     // 登録済みカスタム質問を一覧表示する
-                    ..._settings.customQuestions.asMap().entries.map((entry) {
+                    ..._customQuestions.asMap().entries.map((entry) {
+                      final q = entry.value;
                       return Column(
                         children: [
                           ListTile(
                             title: Text(
-                              entry.value,
+                              q.text,
                               style: TextStyle(
                                 fontSize: 14,
                                 color: c.textPrimary,
                               ),
                             ),
-                            // 削除ボタン
+                            // 削除ボタン（論理削除＝archive）
                             trailing: IconButton(
                               icon: Icon(Icons.delete_outline,
                                   color: c.textSecondary, size: 20),
-                              onPressed: () =>
-                                  _removeCustomQuestion(entry.key),
+                              onPressed: () => _removeCustomQuestion(q.id),
                             ),
                           ),
-                          if (entry.key <
-                              _settings.customQuestions.length - 1)
+                          if (entry.key < _customQuestions.length - 1)
                             Divider(height: 1, color: c.cardBorder),
                         ],
                       );
                     }),
 
                     // 既存質問がある場合は区切り線を入れる
-                    if (_settings.customQuestions.isNotEmpty)
+                    if (_customQuestions.isNotEmpty)
                       Divider(height: 1, color: c.cardBorder),
 
                     // 新しいカスタム質問を入力・追加するフィールド

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -1,71 +1,292 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/app_user.dart';
+import '../models/custom_question.dart';
+import '../models/day_entry.dart';
+import '../models/response_entry.dart';
 import '../models/user_settings.dart';
 
 // Firestoreへのデータ読み書きを担当するサービスクラス
+// スキーマ：
+//   users/{uid}
+//     ├── settings/preferences        (1 doc)
+//     ├── customQuestions/{questionId} (subcollection)
+//     └── days/{YYYY-MM-DD}
+//           └── conversation/{autoId}  (subcollection)
 class FirestoreService {
   final FirebaseFirestore _db = FirebaseFirestore.instance;
 
-  // ユーザーの設定をFirestoreから取得する（存在しなければデフォルト値を返す）
+  // ──────────────────────────────────────────
+  // パスヘルパー
+  // ──────────────────────────────────────────
+
+  DocumentReference<Map<String, dynamic>> _userDoc(String uid) =>
+      _db.collection('users').doc(uid);
+
+  DocumentReference<Map<String, dynamic>> _preferencesDoc(String uid) =>
+      _userDoc(uid).collection('settings').doc('preferences');
+
+  CollectionReference<Map<String, dynamic>> _customQuestionsColl(String uid) =>
+      _userDoc(uid).collection('customQuestions');
+
+  // ResponseEntry.questionRef に保存するため公開
+  DocumentReference<Map<String, dynamic>> customQuestionRef(
+          String uid, String questionId) =>
+      _customQuestionsColl(uid).doc(questionId);
+
+  CollectionReference<Map<String, dynamic>> _daysColl(String uid) =>
+      _userDoc(uid).collection('days');
+
+  DocumentReference<Map<String, dynamic>> _dayDoc(String uid, String date) =>
+      _daysColl(uid).doc(date);
+
+  CollectionReference<Map<String, dynamic>> _conversationColl(
+          String uid, String date) =>
+      _dayDoc(uid, date).collection('conversation');
+
+  // ──────────────────────────────────────────
+  // AppUser (users/{uid})
+  // ──────────────────────────────────────────
+
+  // ユーザープロフィールを取得（未作成ならnull）
+  Future<AppUser?> getAppUser(String uid) async {
+    final doc = await _userDoc(uid).get();
+    if (!doc.exists || doc.data() == null) return null;
+    return AppUser.fromMap(uid, doc.data()!);
+  }
+
+  // ユーザードキュメントを冪等に作成/更新する
+  // - 新規時: createdAt + lastSignInAt + 全フィールドをセット
+  // - 既存時: lastSignInAt と現在の providerId / プロフィール情報を更新
+  // 呼び出し側: AuthService の sign-in 完了直後（匿名/Google問わず）
+  Future<void> ensureAppUser({
+    required String uid,
+    required String providerId,
+    String? displayName,
+    String? email,
+    String? photoUrl,
+  }) async {
+    final docRef = _userDoc(uid);
+    final snap = await docRef.get();
+    final data = <String, dynamic>{
+      'providerId': providerId,
+      'displayName': displayName,
+      'email': email,
+      'photoUrl': photoUrl,
+      'schemaVersion': 1,
+      'lastSignInAt': FieldValue.serverTimestamp(),
+    };
+    if (!snap.exists) {
+      data['createdAt'] = FieldValue.serverTimestamp();
+    }
+    await docRef.set(data, SetOptions(merge: true));
+  }
+
+  // ──────────────────────────────────────────
+  // UserSettings (users/{uid}/settings/preferences)
+  // ──────────────────────────────────────────
+
+  // ユーザーの設定をFirestoreから取得（存在しなければデフォルト値を返す）
   Future<UserSettings> getUserSettings(String uid) async {
-    final doc = await _db
-        .collection('users')
-        .doc(uid)
-        .collection('settings')
-        .doc('preferences')
-        .get();
+    final doc = await _preferencesDoc(uid).get();
     if (doc.exists && doc.data() != null) {
       return UserSettings.fromMap(doc.data()!);
     }
     return UserSettings.defaults();
   }
 
-  // ユーザーの設定をFirestoreに保存する
+  // ユーザーの設定をFirestoreに保存（updatedAtを自動付与）
   Future<void> saveUserSettings(String uid, UserSettings settings) async {
-    await _db
-        .collection('users')
-        .doc(uid)
-        .collection('settings')
-        .doc('preferences')
-        .set(settings.toMap());
+    final data = settings.toMap();
+    data['updatedAt'] = FieldValue.serverTimestamp();
+    await _preferencesDoc(uid).set(data, SetOptions(merge: true));
   }
 
-  // 指定日の日記テキストをFirestoreから取得する（未生成の場合はnullを返す）
-  Future<String?> getTodayDiary(String uid, String date) async {
-    final doc = await _db
-        .collection('users')
-        .doc(uid)
-        .collection('entries')
-        .doc(date)
+  // ──────────────────────────────────────────
+  // CustomQuestions (users/{uid}/customQuestions/{id})
+  // ──────────────────────────────────────────
+
+  // アクティブな質問（archivedAt==null）を order 昇順で取得
+  Future<List<CustomQuestion>> getActiveCustomQuestions(String uid) async {
+    final snap = await _customQuestionsColl(uid)
+        .where('archivedAt', isNull: true)
+        .orderBy('order')
         .get();
-    if (doc.exists && doc.data()?['diary'] != null) {
-      return doc.data()!['diary'] as String;
-    }
-    return null;
+    return snap.docs
+        .map((d) => CustomQuestion.fromMap(d.id, d.data()))
+        .toList();
   }
+
+  // archive 済みも含めて全て取得
+  // 過去日記の表示で archived な質問の文脈を引きたい場合に使う
+  Future<List<CustomQuestion>> getAllCustomQuestions(String uid) async {
+    final snap = await _customQuestionsColl(uid).orderBy('order').get();
+    return snap.docs
+        .map((d) => CustomQuestion.fromMap(d.id, d.data()))
+        .toList();
+  }
+
+  // アクティブな質問の変更を監視するストリーム
+  Stream<List<CustomQuestion>> watchActiveCustomQuestions(String uid) {
+    return _customQuestionsColl(uid)
+        .where('archivedAt', isNull: true)
+        .orderBy('order')
+        .snapshots()
+        .map((snap) => snap.docs
+            .map((d) => CustomQuestion.fromMap(d.id, d.data()))
+            .toList());
+  }
+
+  // 新規追加（auto-IDを発番し、生成された質問IDを返す）
+  Future<String> addCustomQuestion(
+    String uid, {
+    required String text,
+    QuestionType type = QuestionType.text,
+    List<String>? choices,
+    String? unit,
+    double order = 0,
+  }) async {
+    final docRef = _customQuestionsColl(uid).doc();
+    await docRef.set({
+      'text': text,
+      'type': type.value,
+      'choices': choices,
+      'unit': unit,
+      'enabled': true,
+      'order': order,
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+      'archivedAt': null,
+    });
+    return docRef.id;
+  }
+
+  // 既存質問を更新（text / type / order / enabled 等）
+  // archivedAt は対象外。archive は archiveCustomQuestion を使う
+  Future<void> updateCustomQuestion(
+      String uid, CustomQuestion question) async {
+    final data = question.toMap();
+    data['updatedAt'] = FieldValue.serverTimestamp();
+    await _customQuestionsColl(uid)
+        .doc(question.id)
+        .set(data, SetOptions(merge: true));
+  }
+
+  // 論理削除（archivedAt をセット）
+  // 過去日記からの questionRef 参照が壊れないように完全削除はしない
+  Future<void> archiveCustomQuestion(String uid, String questionId) async {
+    await _customQuestionsColl(uid).doc(questionId).set(
+      {
+        'archivedAt': FieldValue.serverTimestamp(),
+        'updatedAt': FieldValue.serverTimestamp(),
+      },
+      SetOptions(merge: true),
+    );
+  }
+
+  // ──────────────────────────────────────────
+  // Days (users/{uid}/days/{date})
+  // ──────────────────────────────────────────
+
+  // 指定日のデータを取得（未生成の場合はnull）
+  Future<DayEntry?> getDay(String uid, String date) async {
+    final doc = await _dayDoc(uid, date).get();
+    if (!doc.exists || doc.data() == null) return null;
+    return DayEntry.fromMap(date, doc.data()!);
+  }
+
+  // 指定日の日記テキストのみ取得
+  Future<String?> getDayDiary(String uid, String date) async {
+    final day = await getDay(uid, date);
+    return day?.diary;
+  }
+
+  // 1日丸ごと保存
+  // - metrics は responses から数値質問だけ抽出して自動生成
+  //   （呼び出し側が忘れる余地をなくし、データ整合性を保証）
+  // - 新規時のみ createdAt をセット、updatedAt は毎回更新
+  Future<void> saveDay(String uid, DayEntry day) async {
+    final docRef = _dayDoc(uid, day.date);
+    final snap = await docRef.get();
+
+    final metrics = <String, double>{};
+    for (final r in day.responses) {
+      if (r.answerNumber != null) {
+        metrics[r.questionKey] = r.answerNumber!;
+      }
+    }
+
+    final data = <String, dynamic>{
+      'diary': day.diary,
+      'diarySource': day.diarySource?.value,
+      'responses': day.responses.map((r) => r.toMap()).toList(),
+      'metrics': metrics,
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+    if (!snap.exists) {
+      data['createdAt'] = FieldValue.serverTimestamp();
+    }
+    await docRef.set(data, SetOptions(merge: true));
+  }
+
+  // 日記テキストのみ保存（編集画面用、source指定可）
+  Future<void> saveDiaryText(
+    String uid,
+    String date,
+    String diary,
+    DiarySource source,
+  ) async {
+    final docRef = _dayDoc(uid, date);
+    final snap = await docRef.get();
+    final data = <String, dynamic>{
+      'diary': diary,
+      'diarySource': source.value,
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+    if (!snap.exists) {
+      data['createdAt'] = FieldValue.serverTimestamp();
+    }
+    await docRef.set(data, SetOptions(merge: true));
+  }
+
+  // 直近 days 日分のエントリを返す
+  Future<List<DayEntry>> getRecentDays(String uid, int days) async {
+    final now = DateTime.now();
+    final from = now.subtract(Duration(days: days - 1));
+    final fromStr = from.toIso8601String().split('T')[0];
+    final toStr = now.toIso8601String().split('T')[0];
+    final snap = await _daysColl(uid)
+        .where(FieldPath.documentId, isGreaterThanOrEqualTo: fromStr)
+        .where(FieldPath.documentId, isLessThanOrEqualTo: toStr)
+        .get();
+    return snap.docs.map((d) => DayEntry.fromMap(d.id, d.data())).toList();
+  }
+
+  // 全エントリを日付の降順で返す（CSVエクスポート用）
+  Future<List<DayEntry>> getAllDays(String uid) async {
+    final snap = await _daysColl(uid).get();
+    final entries =
+        snap.docs.map((d) => DayEntry.fromMap(d.id, d.data())).toList();
+    entries.sort((a, b) => b.date.compareTo(a.date));
+    return entries;
+  }
+
+  // 日記一覧用のクエリ（StreamBuilder で使う）
+  Query<Map<String, dynamic>> daysQuery(String uid) => _daysColl(uid);
+
+  // ──────────────────────────────────────────
+  // Conversation (users/{uid}/days/{date}/conversation)
+  // ──────────────────────────────────────────
 
   // 指定日の会話メッセージ数を返す（追記時のconversationOrderオフセット計算に使う）
   Future<int> getMessageCount(String uid, String date) async {
-    final snap = await _db
-        .collection('users')
-        .doc(uid)
-        .collection('entries')
-        .doc(date)
-        .collection('conversation')
-        .count()
-        .get();
+    final snap = await _conversationColl(uid, date).count().get();
     return snap.count ?? 0;
   }
 
-  // 会話の1メッセージをFirestoreに保存する（順序orderで並び替えできるようにする）
+  // 会話の1メッセージを保存（順序orderで並び替えできるようにする）
   Future<void> saveMessage(
       String uid, String date, String role, String text, int order) async {
-    await _db
-        .collection('users')
-        .doc(uid)
-        .collection('entries')
-        .doc(date)
-        .collection('conversation')
-        .add({
+    await _conversationColl(uid, date).add({
       'role': role,
       'text': text,
       'order': order,
@@ -73,239 +294,345 @@ class FirestoreService {
     });
   }
 
-  // 質問キー→回答テキストのマップをFirestoreに保存する（既存データとマージする）
-  // numericAnswers が渡された場合は数値データも同時に保存する
-  Future<void> saveAnswers(
-      String uid, String date, Map<String, String> answers,
-      {Map<String, double>? numericAnswers}) async {
-    if (answers.isEmpty && (numericAnswers == null || numericAnswers.isEmpty)) {
-      return;
-    }
-    final data = <String, dynamic>{};
-    if (answers.isNotEmpty) data['answers'] = answers;
-    if (numericAnswers != null && numericAnswers.isNotEmpty) {
-      data['numericAnswers'] = numericAnswers;
-    }
-    await _db
-        .collection('users')
-        .doc(uid)
-        .collection('entries')
-        .doc(date)
-        .set(data, SetOptions(merge: true));
-  }
+  // ──────────────────────────────────────────
+  // Mock Data
+  // ──────────────────────────────────────────
 
-  // 直近 days 日分のエントリを日付文字列とデータのペアで返す
-  Future<List<MapEntry<String, Map<String, dynamic>>>> getRecentEntries(
-      String uid, int days) async {
-    final now = DateTime.now();
-    final from = now.subtract(Duration(days: days - 1));
-    final fromStr = from.toIso8601String().split('T')[0];
-    final toStr = now.toIso8601String().split('T')[0];
-
-    final snap = await _db
-        .collection('users')
-        .doc(uid)
-        .collection('entries')
-        .where(FieldPath.documentId, isGreaterThanOrEqualTo: fromStr)
-        .where(FieldPath.documentId, isLessThanOrEqualTo: toStr)
-        .get();
-
-    return snap.docs.map((doc) => MapEntry(doc.id, doc.data())).toList();
-  }
-
-  // 生成した日記テキストをFirestoreに保存する（既存データとマージする）
-  Future<void> saveDiary(String uid, String date, String diary) async {
-    await _db
-        .collection('users')
-        .doc(uid)
-        .collection('entries')
-        .doc(date)
-        .set({
-      'diary': diary,
-      'timestamp': FieldValue.serverTimestamp(),
-    }, SetOptions(merge: true));
-  }
-
-  // デモ用のモックデータを7日分Firestoreに書き込む
+  // デモ用のモックデータを7日分書き込む
+  // 冪等性のため、既存のcustomQuestionsを一度全削除してから再投入する
+  // （days は同じ日付なので saveDay の merge で上書きされる）
   Future<void> seedMockData(String uid) async {
-    final entries = {
-      '2026-03-08': {
-        'diary': '依頼人から、特定の出来事に関する証言を得た。それはプライベートな時間、カフェで初めて注文を全部英語で行った一件。依頼人はその出来事に対し「面白かった」と述べ、「店員さんが普通に対応してくれて少し拍子抜けだった」と評価した。当日の睡眠時間は7時間と記録されている。食事はトースト・カフェのパスタ・冷凍チャーハンを摂取し、運動は実施済み。学習も実施済みであった。午前中は洗濯と部屋の掃除、午後は近所のカフェで読書、夜は友人とオンラインゲームに時間を費やしていたことが確認された。',
-        'answers': {
-          'sleep': '7時間',
-          'food': 'カフェのパスタ',
-          'exercise': 'した',
-          'study': 'した',
-          'custom_0': 'いいえ',
-          'custom_1': 'カフェで初めてオーダーを全部英語でしてみた',
-          'morning': '洗濯と部屋の掃除をした',
-          'afternoon': '近所のカフェで本を読んだ',
-          'evening': '友人とオンラインゲームをした',
-          'event_when': 'プライベート',
-          'event_where': 'カフェ',
-          'event_who': '自分',
-          'event_what': '初めて注文を全部英語でしてみた',
-          'event_how': '面白かった',
-        },
-        'numericAnswers': {'sleep': 7.0},
-      },
-      '2026-03-09': {
-        'diary': '依頼人から、特定の出来事に関する証言を得た。それは昼、学校で図書館の自習室を初めて予約しレポートを書き上げた一件。依頼人はその出来事に対し「嬉しかった」と述べ、「静かで集中できてよかった」と評価した。当日の睡眠時間は6時間と記録されている。食事はおにぎり・学食のカレー・鍋を摂取し、運動は未実施。学習は実施済みであった。午前中は授業（統計学・線形代数）、午後は図書館での課題レポート作業、夜は夕食後すぐ就寝に時間を費やしていたことが確認された。',
-        'answers': {
-          'sleep': '6時間',
-          'food': '学食のカレー',
-          'exercise': 'していない',
-          'study': 'した',
-          'custom_0': 'はい',
-          'custom_1': '図書館の自習室を初めて予約して使った',
-          'morning': '授業（統計学・線形代数）',
-          'afternoon': '図書館で課題レポートを書いた',
-          'evening': '夕食後すぐ寝てしまった',
-          'event_when': '昼',
-          'event_where': '学校',
-          'event_who': '自分',
-          'event_what': '図書館の自習室を初めて予約してレポートを書き上げた',
-          'event_how': '嬉しかった',
-        },
-        'numericAnswers': {'sleep': 6.0},
-      },
-      '2026-03-10': {
-        'diary': '依頼人から、特定の出来事に関する証言を得た。それは昼、学校でPythonのgroupbyのバグをドキュメントをもとに解決した一件。依頼人はその出来事に対し「嬉しかった」と述べ、「やっと解決できてすっきりした」と評価した。当日の睡眠時間は7時間と記録されている。食事はヨーグルト・サンドイッチ・鶏むね肉の照り焼きを摂取し、運動は実施済み。学習も実施済みであった。午前中はプログラミング演習の授業、午後は研究室でのデバッグ作業、夜はジムでのランニングとストレッチに時間を費やしていたことが確認された。',
-        'answers': {
-          'sleep': '7時間',
-          'food': '鶏むね肉の照り焼き（自炊）',
-          'exercise': 'した',
-          'study': 'した',
-          'custom_0': 'いいえ',
-          'custom_1': 'pandasのgroupbyを初めて使いこなせた',
-          'morning': '授業（プログラミング演習）',
-          'afternoon': '研究室でPythonのデバッグ作業',
-          'evening': 'ジムでランニングとストレッチ',
-          'event_when': '昼',
-          'event_where': '学校',
-          'event_who': '自分',
-          'event_what': 'Pythonのgroupbyのバグをドキュメントをもとにやっと解決できた',
-          'event_how': '嬉しかった',
-        },
-        'numericAnswers': {'sleep': 7.0},
-      },
-      '2026-03-11': {
-        'diary': '依頼人から、特定の出来事に関する証言を得た。それは夜、居酒屋で友人とともに苦手なレバーを初めて完食した一件。依頼人はその出来事に対し「面白かった」と述べ、「不思議と食べられて自分でも驚いた」と評価した。当日の睡眠時間は5時間と記録されている。食事はファミレスのモーニング・居酒屋の唐揚げ・枝豆などを摂取し、運動は実施済み。学習も実施済みであった。午前中はオンライン講義（機械学習入門）の視聴、午後は近所の散歩と昼寝、夜は友人との居酒屋に時間を費やしていたことが確認された。',
-        'answers': {
-          'sleep': '5時間',
-          'food': '居酒屋',
-          'exercise': 'した',
-          'study': 'した',
-          'custom_0': 'いいえ',
-          'custom_1': '居酒屋で苦手なレバーを初めて完食できた',
-          'morning': 'オンライン講義（機械学習入門）の視聴',
-          'afternoon': '近所を30分散歩してから昼寝',
-          'evening': '友人と居酒屋に行った',
-          'event_when': '夜',
-          'event_where': '居酒屋',
-          'event_who': '友人と',
-          'event_what': '苦手なレバーを初めて完食できた',
-          'event_how': '面白かった',
-        },
-        'numericAnswers': {'sleep': 5.0},
-      },
-      '2026-03-12': {
-        'diary': '依頼人から、特定の出来事に関する証言を得た。それは昼、学校でヒープを手書きで1から実装した一件。依頼人はその出来事に対し「嬉しかった」と述べ、「意外とすらすら書けて自信がついた」と評価した。当日の睡眠時間は8時間と記録されている。食事は食パン・学食の日替わり定食・コンビニのパスタを摂取し、運動は未実施。学習は実施済みであった。午前中は英語・データ構造の授業、午後は図書館での試験勉強、夜は入浴と読書に時間を費やしていたことが確認された。',
-        'answers': {
-          'sleep': '8時間',
-          'food': '日替わり定食',
-          'exercise': 'していない',
-          'study': 'した',
-          'custom_0': 'はい',
-          'custom_1': 'ヒープの実装を手書きで1から書いてみた',
-          'morning': '授業（英語・データ構造）',
-          'afternoon': '図書館で試験勉強',
-          'evening': '帰宅後すぐ入浴・読書',
-          'event_when': '昼',
-          'event_where': '学校',
-          'event_who': '自分',
-          'event_what': 'ヒープを手書きで実装してみたらすらすら書けた',
-          'event_how': '嬉しかった',
-        },
-        'numericAnswers': {'sleep': 8.0},
-      },
-      '2026-03-13': {
-        'diary': '依頼人から、特定の出来事に関する証言を得た。それは夜、職場でバイト中に常連客へ自分から話しかけた一件。依頼人はその出来事に対し「嬉しかった」と述べ、「新メニューの感想を聞けてよかった」と評価した。当日の睡眠時間は6時間と記録されている。食事はカップ麺・学食のラーメン・まかないのカレーを摂取し、運動は未実施。学習は実施済みであった。午前中は確率論の授業と小テスト、午後はカフェでのアルバイト、夜は帰宅後シャワーを浴びて就寝に時間を費やしていたことが確認された。',
-        'answers': {
-          'sleep': '6時間',
-          'food': 'アルバイト先でまかない（カレー）',
-          'exercise': 'していない',
-          'study': 'した',
-          'custom_0': 'いいえ',
-          'custom_1': 'バイト中に常連さんから新メニューの感想を自分から聞いてみた',
-          'morning': '授業（確率論）・小テスト',
-          'afternoon': 'カフェでアルバイト（16〜21時）',
-          'evening': '帰宅後シャワーを浴びて就寝',
-          'event_when': '夜',
-          'event_where': '職場',
-          'event_who': '自分',
-          'event_what': 'バイト中に常連さんに自分から話しかけて新メニューの感想を聞いた',
-          'event_how': '嬉しかった',
-        },
-        'numericAnswers': {'sleep': 6.0},
-      },
-      '2026-03-14': {
-        'diary': '依頼人から、特定の出来事に関する証言を得た。それはプライベートな時間、自宅でFlutterとGemini APIを連携させAIアプリを初めて動かした一件。依頼人はその出来事に対し「嬉しかった」と述べ、「初めてAIが返答した瞬間は感動だった」と評価した。当日の睡眠時間は9時間と記録されている。食事はホットケーキ・デリバリーのピザ・カップ麺を摂取し、運動は未実施。学習は実施済みであった。午前中はゆっくり起床しYoutubeを見ながらストレッチ、午後はハッカソンの作業、夜はレビュー準備に時間を費やしていたことが確認された。',
-        'answers': {
-          'sleep': '9時間',
-          'food': 'デリバリーのピザ',
-          'exercise': 'していない',
-          'study': 'した',
-          'custom_0': 'いいえ',
-          'custom_1': 'Gemini APIを使ったアプリを初めて動かせた',
-          'morning': 'ゆっくり起床・Youtubeを見ながらストレッチ',
-          'afternoon': 'ハッカソンの作業（Flutterアプリ開発）',
-          'evening': '作業の続き・レビュー準備',
-          'event_when': 'プライベート',
-          'event_where': '自宅',
-          'event_who': '自分',
-          'event_what': 'FlutterとGemini APIを連携させてAIアプリが初めて動いた',
-          'event_how': '嬉しかった',
-        },
-        'numericAnswers': {'sleep': 9.0},
-      },
-    };
+    // 1. プロフィール作成（既存ならlastSignInAt更新）
+    await ensureAppUser(uid: uid, providerId: 'anonymous');
 
-    for (final entry in entries.entries) {
-      await _db
-          .collection('users')
-          .doc(uid)
-          .collection('entries')
-          .doc(entry.key)
-          .set({
-        'diary': entry.value['diary'],
-        'answers': entry.value['answers'],
-        'numericAnswers': entry.value['numericAnswers'],
-        'timestamp': FieldValue.serverTimestamp(),
+    // 2. 設定を全項目ONで上書き
+    await saveUserSettings(
+      uid,
+      const UserSettings(
+        recordEvent: true,
+        recallAssist: true,
+        recordSleep: true,
+        recordFood: true,
+        recordExercise: true,
+        recordStudy: true,
+      ),
+    );
+
+    // 3. 既存のcustomQuestionsを全削除（再投入時の重複防止）
+    final existing = await _customQuestionsColl(uid).get();
+    if (existing.docs.isNotEmpty) {
+      final batch = _db.batch();
+      for (final doc in existing.docs) {
+        batch.delete(doc.reference);
+      }
+      await batch.commit();
+    }
+
+    // 4. カスタム質問を2つ作成（モックデータの custom_0 / custom_1 に対応）
+    final q0Id = await addCustomQuestion(
+      uid,
+      text: '今日、新しいことに挑戦したか?',
+      type: QuestionType.singleChoice,
+      choices: const ['はい', 'いいえ'],
+      order: 1.0,
+    );
+    final q1Id = await addCustomQuestion(
+      uid,
+      text: '今日の新しい発見は?',
+      type: QuestionType.text,
+      order: 2.0,
+    );
+    final q0Ref = customQuestionRef(uid, q0Id);
+    final q1Ref = customQuestionRef(uid, q1Id);
+
+    // 5. 7日分のday entriesを書き込み
+    for (final entry in _mockDayData.entries) {
+      final numericRaw = entry.value['numericAnswers'] as Map;
+      final numericAnswers = <String, double>{};
+      numericRaw.forEach((k, v) {
+        if (k is String && v is num) numericAnswers[k] = v.toDouble();
       });
+
+      final day = _convertMockToDayEntry(
+        date: entry.key,
+        diary: entry.value['diary'] as String,
+        answers: (entry.value['answers'] as Map).cast<String, String>(),
+        numericAnswers: numericAnswers,
+        q0Id: q0Id,
+        q0Ref: q0Ref,
+        q1Id: q1Id,
+        q1Ref: q1Ref,
+      );
+      await saveDay(uid, day);
     }
   }
 
-  // 全エントリを日付の降順で返す（CSVエクスポート用）
-  Future<List<MapEntry<String, Map<String, dynamic>>>> getAllEntries(
-      String uid) async {
-    final snap = await _db
-        .collection('users')
-        .doc(uid)
-        .collection('entries')
-        .get();
-    final entries =
-        snap.docs.map((doc) => MapEntry(doc.id, doc.data())).toList();
-    entries.sort((a, b) => b.key.compareTo(a.key));
-    return entries;
+  // 質問キー → 質問文 のマップ（モック変換用、diary_page.dart の文言と一致させる）
+  static const Map<String, String> _appQuestionTexts = {
+    'sleep': '昨夜は何時間眠った?',
+    'food': '今日、何を口にした?',
+    'exercise': '身体を動かしたか?',
+    'study': '今日、頭を使う作業はしたか?',
+    'morning': '午前中の動向を報告してくれ。',
+    'afternoon': '午後はどう動いた?',
+    'evening': '夜の動向は?',
+    'event_when': 'それはいつの話だ?',
+    'event_where': 'どこで起きた?',
+    'event_who': '誰に関わる話だ?',
+    'event_what': '何があった?話してくれ。',
+    'event_how': 'そのとき、どう感じた?',
+  };
+
+  // 旧スキーマ風のmockデータ（answers/numericAnswers）を新スキーマの DayEntry に変換する
+  DayEntry _convertMockToDayEntry({
+    required String date,
+    required String diary,
+    required Map<String, String> answers,
+    required Map<String, double> numericAnswers,
+    required String q0Id,
+    required DocumentReference<Map<String, dynamic>> q0Ref,
+    required String q1Id,
+    required DocumentReference<Map<String, dynamic>> q1Ref,
+  }) {
+    final responses = <ResponseEntry>[];
+    var order = 0;
+
+    // fixed (sleep / food / exercise / study)
+    for (final key in const ['sleep', 'food', 'exercise', 'study']) {
+      if (answers.containsKey(key)) {
+        final type = (key == 'food')
+            ? QuestionType.text
+            : (key == 'sleep'
+                ? QuestionType.singleChoice
+                : QuestionType.singleChoice);
+        responses.add(ResponseEntry(
+          source: ResponseSource.appFixed,
+          questionKey: key,
+          questionText: _appQuestionTexts[key] ?? key,
+          questionType: type,
+          answerText: answers[key],
+          answerNumber: numericAnswers[key],
+          order: order++,
+        ));
+      }
+    }
+
+    // userCustom (custom_0 / custom_1)
+    if (answers.containsKey('custom_0')) {
+      responses.add(ResponseEntry(
+        source: ResponseSource.userCustom,
+        questionKey: 'custom_$q0Id',
+        questionRef: q0Ref,
+        questionText: '今日、新しいことに挑戦したか?',
+        questionType: QuestionType.singleChoice,
+        answerText: answers['custom_0'],
+        order: order++,
+      ));
+    }
+    if (answers.containsKey('custom_1')) {
+      responses.add(ResponseEntry(
+        source: ResponseSource.userCustom,
+        questionKey: 'custom_$q1Id',
+        questionRef: q1Ref,
+        questionText: '今日の新しい発見は?',
+        questionType: QuestionType.text,
+        answerText: answers['custom_1'],
+        order: order++,
+      ));
+    }
+
+    // recall (morning / afternoon / evening)
+    for (final key in const ['morning', 'afternoon', 'evening']) {
+      if (answers.containsKey(key)) {
+        responses.add(ResponseEntry(
+          source: ResponseSource.appRecall,
+          questionKey: key,
+          questionText: _appQuestionTexts[key] ?? key,
+          questionType: QuestionType.text,
+          answerText: answers[key],
+          order: order++,
+        ));
+      }
+    }
+
+    // event (event_when / where / who / what / how)
+    for (final key in const [
+      'event_when',
+      'event_where',
+      'event_who',
+      'event_what',
+      'event_how',
+    ]) {
+      if (answers.containsKey(key)) {
+        final isFreeText = key == 'event_what';
+        responses.add(ResponseEntry(
+          source: ResponseSource.appEvent,
+          questionKey: key,
+          questionText: _appQuestionTexts[key] ?? key,
+          questionType:
+              isFreeText ? QuestionType.text : QuestionType.singleChoice,
+          answerText: answers[key],
+          order: order++,
+        ));
+      }
+    }
+
+    return DayEntry(
+      date: date,
+      diary: diary,
+      diarySource: DiarySource.ai,
+      responses: responses,
+    );
   }
 
-  // 日記エントリ一覧を取得するクエリを返す
-  // ソートはクライアント側でドキュメントID（YYYY-MM-DD）の降順で行う
-  Query<Map<String, dynamic>> entriesQuery(String uid) {
-    return _db
-        .collection('users')
-        .doc(uid)
-        .collection('entries');
-  }
+  // mockデータ（7日分）。answers/numericAnswers は旧スキーマと同じ内容
+  static const Map<String, Map<String, dynamic>> _mockDayData = {
+    '2026-03-08': {
+      'diary':
+          '依頼人から、特定の出来事に関する証言を得た。それはプライベートな時間、カフェで初めて注文を全部英語で行った一件。依頼人はその出来事に対し「面白かった」と述べ、「店員さんが普通に対応してくれて少し拍子抜けだった」と評価した。当日の睡眠時間は7時間と記録されている。食事はトースト・カフェのパスタ・冷凍チャーハンを摂取し、運動は実施済み。学習も実施済みであった。午前中は洗濯と部屋の掃除、午後は近所のカフェで読書、夜は友人とオンラインゲームに時間を費やしていたことが確認された。',
+      'answers': {
+        'sleep': '7時間',
+        'food': 'カフェのパスタ',
+        'exercise': 'した',
+        'study': 'した',
+        'custom_0': 'いいえ',
+        'custom_1': 'カフェで初めてオーダーを全部英語でしてみた',
+        'morning': '洗濯と部屋の掃除をした',
+        'afternoon': '近所のカフェで本を読んだ',
+        'evening': '友人とオンラインゲームをした',
+        'event_when': 'プライベート',
+        'event_where': 'カフェ',
+        'event_who': '自分',
+        'event_what': '初めて注文を全部英語でしてみた',
+        'event_how': '面白かった',
+      },
+      'numericAnswers': {'sleep': 7.0},
+    },
+    '2026-03-09': {
+      'diary':
+          '依頼人から、特定の出来事に関する証言を得た。それは昼、学校で図書館の自習室を初めて予約しレポートを書き上げた一件。依頼人はその出来事に対し「嬉しかった」と述べ、「静かで集中できてよかった」と評価した。当日の睡眠時間は6時間と記録されている。食事はおにぎり・学食のカレー・鍋を摂取し、運動は未実施。学習は実施済みであった。午前中は授業（統計学・線形代数）、午後は図書館での課題レポート作業、夜は夕食後すぐ就寝に時間を費やしていたことが確認された。',
+      'answers': {
+        'sleep': '6時間',
+        'food': '学食のカレー',
+        'exercise': 'していない',
+        'study': 'した',
+        'custom_0': 'はい',
+        'custom_1': '図書館の自習室を初めて予約して使った',
+        'morning': '授業（統計学・線形代数）',
+        'afternoon': '図書館で課題レポートを書いた',
+        'evening': '夕食後すぐ寝てしまった',
+        'event_when': '昼',
+        'event_where': '学校',
+        'event_who': '自分',
+        'event_what': '図書館の自習室を初めて予約してレポートを書き上げた',
+        'event_how': '嬉しかった',
+      },
+      'numericAnswers': {'sleep': 6.0},
+    },
+    '2026-03-10': {
+      'diary':
+          '依頼人から、特定の出来事に関する証言を得た。それは昼、学校でPythonのgroupbyのバグをドキュメントをもとに解決した一件。依頼人はその出来事に対し「嬉しかった」と述べ、「やっと解決できてすっきりした」と評価した。当日の睡眠時間は7時間と記録されている。食事はヨーグルト・サンドイッチ・鶏むね肉の照り焼きを摂取し、運動は実施済み。学習も実施済みであった。午前中はプログラミング演習の授業、午後は研究室でのデバッグ作業、夜はジムでのランニングとストレッチに時間を費やしていたことが確認された。',
+      'answers': {
+        'sleep': '7時間',
+        'food': '鶏むね肉の照り焼き（自炊）',
+        'exercise': 'した',
+        'study': 'した',
+        'custom_0': 'いいえ',
+        'custom_1': 'pandasのgroupbyを初めて使いこなせた',
+        'morning': '授業（プログラミング演習）',
+        'afternoon': '研究室でPythonのデバッグ作業',
+        'evening': 'ジムでランニングとストレッチ',
+        'event_when': '昼',
+        'event_where': '学校',
+        'event_who': '自分',
+        'event_what': 'Pythonのgroupbyのバグをドキュメントをもとにやっと解決できた',
+        'event_how': '嬉しかった',
+      },
+      'numericAnswers': {'sleep': 7.0},
+    },
+    '2026-03-11': {
+      'diary':
+          '依頼人から、特定の出来事に関する証言を得た。それは夜、居酒屋で友人とともに苦手なレバーを初めて完食した一件。依頼人はその出来事に対し「面白かった」と述べ、「不思議と食べられて自分でも驚いた」と評価した。当日の睡眠時間は5時間と記録されている。食事はファミレスのモーニング・居酒屋の唐揚げ・枝豆などを摂取し、運動は実施済み。学習も実施済みであった。午前中はオンライン講義（機械学習入門）の視聴、午後は近所の散歩と昼寝、夜は友人との居酒屋に時間を費やしていたことが確認された。',
+      'answers': {
+        'sleep': '5時間',
+        'food': '居酒屋',
+        'exercise': 'した',
+        'study': 'した',
+        'custom_0': 'いいえ',
+        'custom_1': '居酒屋で苦手なレバーを初めて完食できた',
+        'morning': 'オンライン講義（機械学習入門）の視聴',
+        'afternoon': '近所を30分散歩してから昼寝',
+        'evening': '友人と居酒屋に行った',
+        'event_when': '夜',
+        'event_where': '居酒屋',
+        'event_who': '友人と',
+        'event_what': '苦手なレバーを初めて完食できた',
+        'event_how': '面白かった',
+      },
+      'numericAnswers': {'sleep': 5.0},
+    },
+    '2026-03-12': {
+      'diary':
+          '依頼人から、特定の出来事に関する証言を得た。それは昼、学校でヒープを手書きで1から実装した一件。依頼人はその出来事に対し「嬉しかった」と述べ、「意外とすらすら書けて自信がついた」と評価した。当日の睡眠時間は8時間と記録されている。食事は食パン・学食の日替わり定食・コンビニのパスタを摂取し、運動は未実施。学習は実施済みであった。午前中は英語・データ構造の授業、午後は図書館での試験勉強、夜は入浴と読書に時間を費やしていたことが確認された。',
+      'answers': {
+        'sleep': '8時間',
+        'food': '日替わり定食',
+        'exercise': 'していない',
+        'study': 'した',
+        'custom_0': 'はい',
+        'custom_1': 'ヒープの実装を手書きで1から書いてみた',
+        'morning': '授業（英語・データ構造）',
+        'afternoon': '図書館で試験勉強',
+        'evening': '帰宅後すぐ入浴・読書',
+        'event_when': '昼',
+        'event_where': '学校',
+        'event_who': '自分',
+        'event_what': 'ヒープを手書きで実装してみたらすらすら書けた',
+        'event_how': '嬉しかった',
+      },
+      'numericAnswers': {'sleep': 8.0},
+    },
+    '2026-03-13': {
+      'diary':
+          '依頼人から、特定の出来事に関する証言を得た。それは夜、職場でバイト中に常連客へ自分から話しかけた一件。依頼人はその出来事に対し「嬉しかった」と述べ、「新メニューの感想を聞けてよかった」と評価した。当日の睡眠時間は6時間と記録されている。食事はカップ麺・学食のラーメン・まかないのカレーを摂取し、運動は未実施。学習は実施済みであった。午前中は確率論の授業と小テスト、午後はカフェでのアルバイト、夜は帰宅後シャワーを浴びて就寝に時間を費やしていたことが確認された。',
+      'answers': {
+        'sleep': '6時間',
+        'food': 'アルバイト先でまかない（カレー）',
+        'exercise': 'していない',
+        'study': 'した',
+        'custom_0': 'いいえ',
+        'custom_1': 'バイト中に常連さんから新メニューの感想を自分から聞いてみた',
+        'morning': '授業（確率論）・小テスト',
+        'afternoon': 'カフェでアルバイト（16〜21時）',
+        'evening': '帰宅後シャワーを浴びて就寝',
+        'event_when': '夜',
+        'event_where': '職場',
+        'event_who': '自分',
+        'event_what': 'バイト中に常連さんに自分から話しかけて新メニューの感想を聞いた',
+        'event_how': '嬉しかった',
+      },
+      'numericAnswers': {'sleep': 6.0},
+    },
+    '2026-03-14': {
+      'diary':
+          '依頼人から、特定の出来事に関する証言を得た。それはプライベートな時間、自宅でFlutterとGemini APIを連携させAIアプリを初めて動かした一件。依頼人はその出来事に対し「嬉しかった」と述べ、「初めてAIが返答した瞬間は感動だった」と評価した。当日の睡眠時間は9時間と記録されている。食事はホットケーキ・デリバリーのピザ・カップ麺を摂取し、運動は未実施。学習は実施済みであった。午前中はゆっくり起床しYoutubeを見ながらストレッチ、午後はハッカソンの作業、夜はレビュー準備に時間を費やしていたことが確認された。',
+      'answers': {
+        'sleep': '9時間',
+        'food': 'デリバリーのピザ',
+        'exercise': 'していない',
+        'study': 'した',
+        'custom_0': 'いいえ',
+        'custom_1': 'Gemini APIを使ったアプリを初めて動かせた',
+        'morning': 'ゆっくり起床・Youtubeを見ながらストレッチ',
+        'afternoon': 'ハッカソンの作業（Flutterアプリ開発）',
+        'evening': '作業の続き・レビュー準備',
+        'event_when': 'プライベート',
+        'event_where': '自宅',
+        'event_who': '自分',
+        'event_what': 'FlutterとGemini APIを連携させてAIアプリが初めて動いた',
+        'event_how': '嬉しかった',
+      },
+      'numericAnswers': {'sleep': 9.0},
+    },
+  };
 }


### PR DESCRIPTION
なぜ:
- 近日中のGoogleログイン移行に備え users/{uid} プロフィール本体を新設
- 質問の出所（アプリ/ユーザー）をキープレフィックスから source フィールドに構造化
- カスタム質問を UserSettings の List<String> から独立サブコレクションに分離し、CRUD・並び替え・archive を構造的に
- 質問テキストのスナップショットを responses[] に保持し、質問編集後も過去日記の文脈を保つ

主な変更:
- entries → days リネーム、responses[] と metrics マップを併設（数値は metrics で O(1) アクセス、responses[] が真実のソース）
- customQuestions サブコレクション化、archivedAt による論理削除
- firestore.rules / firestore.indexes.json を新規作成し firebase.json に登録
- FirestoreService 全面書換、saveDay で responses+metrics を一括コミット
- diary_page を _askedQuestions メタ管理に書換、saveDay 一括保存に統一
- analytics_page を DayEntry/metrics ベースに、CSV は questionText 列ベースに