### PR TITLE
fix: 追記フローで_gemini未初期化によるLateInitializationErrorを修正

### DIFF
--- a/lib/pages/diary_page.dart
+++ b/lib/pages/diary_page.dart
@@ -184,6 +184,9 @@ class _DiaryPageState extends State<DiaryPage> {
     setState(() => _isLoading = true);
     try {
       final settings = await _firestore.getUserSettings(_uid!);
+      // 既存日記ありの経路では _initSession が _gemini を代入する前に return している。
+      // 追記フローではここが _gemini の唯一の代入箇所になる（late final の単一代入を満たす）。
+      _gemini = GeminiService(_apiKey, settings.selectedRole);
       _buildQueues(settings);
       await _askNext();
     } catch (e) {


### PR DESCRIPTION
既存日記がある状態で「追記する」を選ぶと、_initSession が _gemini を初期化せず早期 return しているため、_askAiFollowUp / _generateDiary で _gemini にアクセスした瞬間に LateInitializationError が発生し「AIエラー」「日記生成エラー」になっていた。_handleExistingDiaryChoice の追記分岐で _buildQueues の前に _gemini を初期化する（late final の単一代入は両経路でちょうど1回ずつ保たれる）。