### PR TITLE
プログレスバーを追加

### DIFF
--- a/lib/pages/diary_page.dart
+++ b/lib/pages/diary_page.dart
@@ -1092,8 +1092,9 @@ class _DiaryPageState extends State<DiaryPage> {
               _phase != _Phase.diaryView &&
               _phase != _Phase.done)
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
               child: LinearProgressIndicator(
+                minHeight: 8,
                 value: _answeredQuestionCount / _totalQuestions,
                 backgroundColor: c.appBarBg,
                 valueColor: AlwaysStoppedAnimation<Color>(c.gold),

--- a/lib/pages/diary_page.dart
+++ b/lib/pages/diary_page.dart
@@ -93,6 +93,11 @@ class _DiaryPageState extends State<DiaryPage> {
   // 設定値（selectedRole）が未知でも roleFor() がデフォルトロールへフォールバックする。
   late Role _currentRole;
 
+  int _totalQuestions = 0;
+  int _answeredQuestionCount = 0;
+
+
+
   // メインの出来事質問リスト（key→ロール定義の文面、無ければここの text をデフォルトに使う）
   static const List<_Question> _eventQuestions = [
     _Question(
@@ -276,7 +281,15 @@ class _DiaryPageState extends State<DiaryPage> {
 
     // ── メインの出来事質問キュー ──
     _enqueueEventQuestions();
+
+    _calcTotalQuestions();
   }
+
+
+  void _calcTotalQuestions() {
+    _totalQuestions = _customQueue.length + _recallQueue.length + _eventQueue.length;
+  }
+
 
   // _eventQuestions をキューに積む。ロール定義の質問文があれば text を差し替え、
   // 無ければ元の text をデフォルトとして使う。choices・key は保持する。
@@ -424,6 +437,9 @@ class _DiaryPageState extends State<DiaryPage> {
         final hours = _parseSleepHours(text);
         if (hours != null) _numericAnswers['sleep'] = hours;
       }
+
+      _answeredQuestionCount++;
+
       _pendingKey = null;
     }
 
@@ -1069,6 +1085,22 @@ class _DiaryPageState extends State<DiaryPage> {
                 ],
               ),
             ),
+
+          // 進捗バー（質問フェーズ中のみ表示）
+          if (_totalQuestions > 0 &&
+              !_diaryGenerated &&
+              _phase != _Phase.diaryView &&
+              _phase != _Phase.done)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              child: LinearProgressIndicator(
+                value: _answeredQuestionCount / _totalQuestions,
+                backgroundColor: c.appBarBg,
+                valueColor: AlwaysStoppedAnimation<Color>(c.gold),
+              ),
+            ),
+
+
           if (!_showExistingDiaryChoice && showInput)
             InputArea(controller: _textController, onSubmit: _sendUserReply),
         ],


### PR DESCRIPTION
## 概要
日記作成画面に進捗バーを追加する（Issue #130）

## 変更内容
- `_totalQuestions`・`_answeredQuestionCount` 変数を追加
- `_calcTotalQuestions()` メソッドを新規作成（`_buildQueues()`完了後に総問数を計算）
- `_sendUserReply()` 内の `_pendingKey != null` ブロックで回答済み問数をインクリメント
- `build()` の `InputArea` 直上に `LinearProgressIndicator` を追加

## 設計の意図
- **配置を下部にした理由**: 質問文がチャット形式で下から出てくる構造のため、AIローディング中にユーザーの視線が自然に画面下部に向く
- **分母の計算タイミング**: `_buildQueues()` 完了後にセッション開始時点で確定（ユーザー設定に依存するがセッション中は不変）
- **aiFollowUpの扱い**: 総問数が事前に確定できないため、回答完了時に+1する設計（YAGNI原則に基づき現時点では簡易実装）
- **防御プログラミング**: `_totalQuestions > 0` の条件で0除算を防止

## 表示条件
`custom` 〜 `addendum` フェーズのみ表示（`diaryView`・`done` フェーズは非表示）

## 関連Issue
Close #130