### PR TITLE
feat: 証拠分析室に今日の行動セクションを追加 (#97)

### DIFF
--- a/lib/pages/analytics_page.dart
+++ b/lib/pages/analytics_page.dart
@@ -86,7 +86,20 @@ class _AnalyticsPageState extends State<AnalyticsPage> {
         if (dailyComment != null) {
           _dailyAnalysisText = dailyComment['text'] as String?;
           final ts = dailyComment['generatedAt'];
-          if (ts is Timestamp) _dailyAnalysisGeneratedAt = ts.toDate();
+          if (ts is Timestamp) {
+            final generated = ts.toDate();
+            final now = DateTime.now();
+            final isToday = generated.year == now.year &&
+                generated.month == now.month &&
+                generated.day == now.day;
+            if (isToday) {
+              _dailyAnalysisGeneratedAt = generated;
+            } else {
+              // 日付が変わっている場合は古いキャッシュなので表示しない
+              _dailyAnalysisText = null;
+              _dailyAnalysisGeneratedAt = null;
+            }
+          }
         }
         _isLoading = false;
       });

--- a/lib/pages/analytics_page.dart
+++ b/lib/pages/analytics_page.dart
@@ -23,6 +23,7 @@ class _AnalyticsPageState extends State<AnalyticsPage> {
 
   bool _isLoading = true;
   bool _isGeneratingAnalysis = false;
+  bool _isGeneratingDailyAnalysis = false;
   // YYYY-MM-DD → 睡眠時間（記録なし日はnull）
   final Map<String, double?> _sleepData = {};
   // YYYY-MM-DD → エントリ全データ
@@ -30,7 +31,9 @@ class _AnalyticsPageState extends State<AnalyticsPage> {
   UserSettings? _settings;
   _AnalyticsSummary? _summary;
   String? _analysisText;
+  String? _dailyAnalysisText;
   DateTime? _analysisGeneratedAt;
+  DateTime? _dailyAnalysisGeneratedAt;
 
   static const int _days = 14;
 
@@ -48,16 +51,17 @@ class _AnalyticsPageState extends State<AnalyticsPage> {
       final entriesFuture = _firestore.getRecentEntries(uid, _days);
       final settingsFuture = _firestore.getUserSettings(uid);
       final analysisFuture = _firestore.getLatestAnalysis(uid);
+      final dailyCommentFuture = _firestore.getTodayComment(uid);
       final entries = await entriesFuture;
       final settings = await settingsFuture;
       final analysis = await analysisFuture;
+      final dailyComment = await dailyCommentFuture;
 
       final sleepData = <String, double?>{};
       final entriesData = <String, Map<String, dynamic>>{};
       for (final entry in entries) {
         entriesData[entry.key] = entry.value;
-        final numeric =
-            entry.value['numericAnswers'] as Map<String, dynamic>?;
+        final numeric = entry.value['numericAnswers'] as Map<String, dynamic>?;
         final sleep = numeric?['sleep'];
         sleepData[entry.key] = sleep != null ? (sleep as num).toDouble() : null;
       }
@@ -79,6 +83,11 @@ class _AnalyticsPageState extends State<AnalyticsPage> {
           final ts = analysis['generatedAt'];
           if (ts is Timestamp) _analysisGeneratedAt = ts.toDate();
         }
+        if (dailyComment != null) {
+          _dailyAnalysisText = dailyComment['text'] as String?;
+          final ts = dailyComment['generatedAt'];
+          if (ts is Timestamp) _dailyAnalysisGeneratedAt = ts.toDate();
+        }
         _isLoading = false;
       });
     } catch (_) {
@@ -89,16 +98,16 @@ class _AnalyticsPageState extends State<AnalyticsPage> {
   Future<void> _generateAnalysis() async {
     if (_isGeneratingAnalysis) return;
     if (_entriesData.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('まだ事件簿が記録されていない')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('まだ事件簿が記録されていない')));
       return;
     }
     final gemini = _gemini;
     if (gemini == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('初期化が完了していない')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('初期化が完了していない')));
       return;
     }
     setState(() => _isGeneratingAnalysis = true);
@@ -118,9 +127,58 @@ class _AnalyticsPageState extends State<AnalyticsPage> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _isGeneratingAnalysis = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('所見の生成に失敗した: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('所見の生成に失敗した: $e')));
+    }
+  }
+
+  Future<void> _generateDailyAnalysis() async {
+    if (_isGeneratingDailyAnalysis) return;
+    if (_entriesData.isEmpty) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('まだ事件簿が記録されていない')));
+      return;
+    }
+    final gemini = _gemini;
+    if (gemini == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('初期化が完了していない')));
+      return;
+    }
+    setState(() => _isGeneratingDailyAnalysis = true);
+    try {
+      final uid = FirebaseAuth.instance.currentUser!.uid;
+      final today = DateTime.now().toIso8601String().split('T')[0];
+      final todayEntry = _entriesData[today];
+
+      if (todayEntry == null) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('今日の記録がまだない')));
+        setState(() => _isGeneratingDailyAnalysis = false);
+        return;
+      }
+
+      final recentEntries = _entriesData.entries
+          .map((e) => MapEntry(e.key, e.value))
+          .toList();
+      final text = await gemini.generateDailyComment(todayEntry, recentEntries);
+      await _firestore.saveTodayComment(uid, text);
+      if (!mounted) return;
+      setState(() {
+        _dailyAnalysisText = text;
+        _dailyAnalysisGeneratedAt = DateTime.now();
+        _isGeneratingDailyAnalysis = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _isGeneratingDailyAnalysis = false);
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('コメントの生成に失敗した: $e')));
     }
   }
 
@@ -147,12 +205,17 @@ class _AnalyticsPageState extends State<AnalyticsPage> {
         title: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('証拠分析室',
-                style: DetectiveTextStyles.appBarTitle(color: c.appBarFg)),
+            Text(
+              '証拠分析室',
+              style: DetectiveTextStyles.appBarTitle(color: c.appBarFg),
+            ),
             const SizedBox(height: 2),
-            Text('― データを読む ―',
-                style: DetectiveTextStyles.appBarSubtitle(
-                    color: c.appBarSubtitle)),
+            Text(
+              '― データを読む ―',
+              style: DetectiveTextStyles.appBarSubtitle(
+                color: c.appBarSubtitle,
+              ),
+            ),
           ],
         ),
       ),
@@ -170,6 +233,15 @@ class _AnalyticsPageState extends State<AnalyticsPage> {
                     generatedAt: _analysisGeneratedAt,
                     isLoading: _isGeneratingAnalysis,
                     onGenerate: _generateAnalysis,
+                  ),
+                  const SizedBox(height: 32),
+                  _SectionHeader(title: '今日の行動', subtitle: '本日分'),
+                  const SizedBox(height: 16),
+                  _AiInsightSection(
+                    text: _dailyAnalysisText,
+                    generatedAt: _dailyAnalysisGeneratedAt,
+                    isLoading: _isGeneratingDailyAnalysis,
+                    onGenerate: _generateDailyAnalysis,
                   ),
                   const SizedBox(height: 32),
                   _SectionHeader(title: 'サマリー', subtitle: '直近$_days日間'),
@@ -216,12 +288,14 @@ class _SectionHeader extends StatelessWidget {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        Text(title,
-            style: DetectiveTextStyles.cardTitle(color: c.textPrimary)
-                .copyWith(fontSize: 18)),
+        Text(
+          title,
+          style: DetectiveTextStyles.cardTitle(
+            color: c.textPrimary,
+          ).copyWith(fontSize: 18),
+        ),
         const SizedBox(width: 8),
-        Text(subtitle,
-            style: TextStyle(fontSize: 12, color: c.textSecondary)),
+        Text(subtitle, style: TextStyle(fontSize: 12, color: c.textSecondary)),
       ],
     );
   }
@@ -242,20 +316,23 @@ class _SleepChart extends StatelessWidget {
     final barGroups = <BarChartGroupData>[];
     for (var i = 0; i < dates.length; i++) {
       final hours = sleepData[dates[i]];
-      barGroups.add(BarChartGroupData(
-        x: i,
-        barRods: [
-          BarChartRodData(
-            toY: hours ?? 0,
-            color: hours != null
-                ? c.gold
-                : c.goldLight.withValues(alpha: 0.2),
-            width: 14,
-            borderRadius:
-                const BorderRadius.vertical(top: Radius.circular(4)),
-          ),
-        ],
-      ));
+      barGroups.add(
+        BarChartGroupData(
+          x: i,
+          barRods: [
+            BarChartRodData(
+              toY: hours ?? 0,
+              color: hours != null
+                  ? c.gold
+                  : c.goldLight.withValues(alpha: 0.2),
+              width: 14,
+              borderRadius: const BorderRadius.vertical(
+                top: Radius.circular(4),
+              ),
+            ),
+          ],
+        ),
+      );
     }
 
     return Container(
@@ -275,10 +352,8 @@ class _SleepChart extends StatelessWidget {
             gridData: FlGridData(
               show: true,
               horizontalInterval: 2,
-              getDrawingHorizontalLine: (value) => FlLine(
-                color: c.cardBorder,
-                strokeWidth: 1,
-              ),
+              getDrawingHorizontalLine: (value) =>
+                  FlLine(color: c.cardBorder, strokeWidth: 1),
               drawVerticalLine: false,
             ),
             borderData: FlBorderData(show: false),
@@ -309,17 +384,18 @@ class _SleepChart extends StatelessWidget {
                       angle: -0.4,
                       child: Text(
                         '${parts[1]}/${parts[2]}',
-                        style:
-                            TextStyle(fontSize: 9, color: c.textSecondary),
+                        style: TextStyle(fontSize: 9, color: c.textSecondary),
                       ),
                     );
                   },
                 ),
               ),
               topTitles: const AxisTitles(
-                  sideTitles: SideTitles(showTitles: false)),
+                sideTitles: SideTitles(showTitles: false),
+              ),
               rightTitles: const AxisTitles(
-                  sideTitles: SideTitles(showTitles: false)),
+                sideTitles: SideTitles(showTitles: false),
+              ),
             ),
             barTouchData: BarTouchData(
               touchTooltipData: BarTouchTooltipData(
@@ -388,43 +464,41 @@ class _RecordsTable extends StatelessWidget {
           headingRowHeight: 38,
           dataRowMinHeight: 36,
           dataRowMaxHeight: 52,
-          headingRowColor:
-              WidgetStateProperty.all(c.gold.withValues(alpha: 0.12)),
+          headingRowColor: WidgetStateProperty.all(
+            c.gold.withValues(alpha: 0.12),
+          ),
           headingTextStyle: TextStyle(
             color: c.textPrimary,
             fontWeight: FontWeight.bold,
             fontSize: 12,
           ),
-          dataTextStyle: TextStyle(
-            color: c.textSecondary,
-            fontSize: 12,
-          ),
+          dataTextStyle: TextStyle(color: c.textSecondary, fontSize: 12),
           dividerThickness: 0.5,
-          columns: allHeaders
-              .map((h) => DataColumn(label: Text(h)))
-              .toList(),
+          columns: allHeaders.map((h) => DataColumn(label: Text(h))).toList(),
           rows: dates.map((date) {
-            final answers = entriesData[date]?['answers']
-                as Map<String, dynamic>?;
+            final answers =
+                entriesData[date]?['answers'] as Map<String, dynamic>?;
             final parts = date.split('-');
             final dateLabel = '${parts[1]}/${parts[2]}';
 
             final fixedCells = [
-              DataCell(Text(dateLabel,
+              DataCell(
+                Text(
+                  dateLabel,
                   style: TextStyle(
-                      fontWeight: FontWeight.w600,
-                      color: c.textPrimary,
-                      fontSize: 12))),
+                    fontWeight: FontWeight.w600,
+                    color: c.textPrimary,
+                    fontSize: 12,
+                  ),
+                ),
+              ),
               ..._fixedKeys.map((key) {
                 final val = answers?[key] as String?;
                 return DataCell(_TableCell(value: val));
               }),
             ];
 
-            final customCells = customQuestions
-                .asMap()
-                .entries
-                .map((e) {
+            final customCells = customQuestions.asMap().entries.map((e) {
               final val = answers?['custom_${e.key}'] as String?;
               return DataCell(_TableCell(value: val));
             }).toList();
@@ -446,8 +520,7 @@ class _TableCell extends StatelessWidget {
   Widget build(BuildContext context) {
     final c = context.colors;
     if (value == null) {
-      return Text('—',
-          style: TextStyle(color: c.cardBorder, fontSize: 12));
+      return Text('—', style: TextStyle(color: c.cardBorder, fontSize: 12));
     }
     return Text(
       value!,
@@ -534,8 +607,9 @@ class _AnalyticsSummary {
       avgSleep: sleeps.isEmpty
           ? null
           : sleeps.reduce((a, b) => a + b) / sleeps.length,
-      exerciseRate:
-          exerciseRecorded == 0 ? null : exerciseDone / exerciseRecorded,
+      exerciseRate: exerciseRecorded == 0
+          ? null
+          : exerciseDone / exerciseRecorded,
       studyRate: studyRecorded == 0 ? null : studyDone / studyRecorded,
       streakDays: streak,
       recordedDays: recordedSet.length,
@@ -562,9 +636,7 @@ class _SummaryCards extends StatelessWidget {
     final cards = <Widget>[
       _StatCard(
         label: '平均睡眠',
-        value: s.avgSleep == null
-            ? '—'
-            : '${s.avgSleep!.toStringAsFixed(1)}h',
+        value: s.avgSleep == null ? '—' : '${s.avgSleep!.toStringAsFixed(1)}h',
       ),
       _StatCard(
         label: '運動実施率',
@@ -574,14 +646,9 @@ class _SummaryCards extends StatelessWidget {
       ),
       _StatCard(
         label: '勉強実施率',
-        value: s.studyRate == null
-            ? '—'
-            : '${(s.studyRate! * 100).round()}%',
+        value: s.studyRate == null ? '—' : '${(s.studyRate! * 100).round()}%',
       ),
-      _StatCard(
-        label: '連続記録',
-        value: '${s.streakDays}日',
-      ),
+      _StatCard(label: '連続記録', value: '${s.streakDays}日'),
     ];
 
     return LayoutBuilder(
@@ -623,13 +690,13 @@ class _StatCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(label,
-              style: TextStyle(fontSize: 11, color: c.textSecondary)),
+          Text(label, style: TextStyle(fontSize: 11, color: c.textSecondary)),
           const SizedBox(height: 6),
           Text(
             value,
-            style: DetectiveTextStyles.cardTitle(color: c.gold)
-                .copyWith(fontSize: 22),
+            style: DetectiveTextStyles.cardTitle(
+              color: c.gold,
+            ).copyWith(fontSize: 22),
           ),
         ],
       ),
@@ -668,11 +735,7 @@ class _DistributionCharts extends StatelessWidget {
           );
         }
         return Column(
-          children: [
-            emotionChart,
-            const SizedBox(height: 12),
-            placeChart,
-          ],
+          children: [emotionChart, const SizedBox(height: 12), placeChart],
         );
       },
     );
@@ -706,16 +769,19 @@ class _PieCard extends StatelessWidget {
     for (var i = 0; i < sortedEntries.length; i++) {
       final e = sortedEntries[i];
       final color = _palette[i % _palette.length];
-      sections.add(PieChartSectionData(
-        value: e.value.toDouble(),
-        color: color,
-        title: '${(e.value / total * 100).round()}%',
-        titleStyle: const TextStyle(
+      sections.add(
+        PieChartSectionData(
+          value: e.value.toDouble(),
+          color: color,
+          title: '${(e.value / total * 100).round()}%',
+          titleStyle: const TextStyle(
             fontSize: 10,
             fontWeight: FontWeight.bold,
-            color: Colors.white),
-        radius: 52,
-      ));
+            color: Colors.white,
+          ),
+          radius: 52,
+        ),
+      );
     }
 
     return Container(
@@ -728,9 +794,12 @@ class _PieCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(title,
-              style: DetectiveTextStyles.cardTitle(color: c.textPrimary)
-                  .copyWith(fontSize: 14)),
+          Text(
+            title,
+            style: DetectiveTextStyles.cardTitle(
+              color: c.textPrimary,
+            ).copyWith(fontSize: 14),
+          ),
           const SizedBox(height: 8),
           SizedBox(
             height: 140,
@@ -764,15 +833,15 @@ class _PieCard extends StatelessWidget {
                   Expanded(
                     child: Text(
                       label,
-                      style:
-                          TextStyle(fontSize: 11, color: c.textSecondary),
+                      style: TextStyle(fontSize: 11, color: c.textSecondary),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),
-                  Text('$count',
-                      style: TextStyle(
-                          fontSize: 11, color: c.textSecondary)),
+                  Text(
+                    '$count',
+                    style: TextStyle(fontSize: 11, color: c.textSecondary),
+                  ),
                 ],
               ),
             );
@@ -828,19 +897,21 @@ class _AiInsightSection extends StatelessWidget {
                   width: 16,
                   height: 16,
                   child: CircularProgressIndicator(
-                      strokeWidth: 2, color: c.gold),
+                    strokeWidth: 2,
+                    color: c.gold,
+                  ),
                 ),
                 const SizedBox(width: 10),
-                Text('探偵が記録を読み返している…',
-                    style: TextStyle(
-                        fontSize: 13, color: c.textSecondary)),
+                Text(
+                  '探偵が記録を読み返している…',
+                  style: TextStyle(fontSize: 13, color: c.textSecondary),
+                ),
               ],
             ),
           ] else if (hasText) ...[
             Text(
               text!,
-              style: TextStyle(
-                  fontSize: 13, color: c.textPrimary, height: 1.6),
+              style: TextStyle(fontSize: 13, color: c.textPrimary, height: 1.6),
             ),
             const SizedBox(height: 12),
             Row(
@@ -849,16 +920,17 @@ class _AiInsightSection extends StatelessWidget {
                 if (generatedAt != null)
                   Text(
                     '記録: ${_formatTimestamp(generatedAt!)}',
-                    style:
-                        TextStyle(fontSize: 10, color: c.textSecondary),
+                    style: TextStyle(fontSize: 10, color: c.textSecondary),
                   )
                 else
                   const SizedBox.shrink(),
                 TextButton.icon(
                   onPressed: onGenerate,
                   icon: Icon(Icons.refresh, size: 16, color: c.gold),
-                  label: Text('再推理',
-                      style: TextStyle(color: c.gold, fontSize: 12)),
+                  label: Text(
+                    '再推理',
+                    style: TextStyle(color: c.gold, fontSize: 12),
+                  ),
                 ),
               ],
             ),
@@ -903,8 +975,10 @@ class _EmptyCard extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: c.cardBorder),
       ),
-      child: Text(message,
-          style: TextStyle(fontSize: 12, color: c.textSecondary)),
+      child: Text(
+        message,
+        style: TextStyle(fontSize: 12, color: c.textSecondary),
+      ),
     );
   }
 }

--- a/lib/prompts/diary_prompts.dart
+++ b/lib/prompts/diary_prompts.dart
@@ -6,8 +6,10 @@ class DiaryPrompts {
 
   // 会話履歴から日記生成プロンプトを組み立てる。
   // additionalContext: カスタム質問・思い出しアシストの回答など
-  static String buildDiaryPrompt(String conversationHistory,
-      {String additionalContext = ''}) {
+  static String buildDiaryPrompt(
+    String conversationHistory, {
+    String additionalContext = '',
+  }) {
     final extra = additionalContext.isNotEmpty
         ? '\n\n【参考情報（日記に自然に織り込むこと）】\n$additionalContext'
         : '';
@@ -17,8 +19,10 @@ class DiaryPrompts {
   // 既存日記と追記インタビューを統合する日記生成プロンプトを組み立てる。
   // additionalContext: カスタム質問・思い出しアシストの回答など
   static String buildDiaryWithExistingPrompt(
-      String existingDiary, String conversationHistory,
-      {String additionalContext = ''}) {
+    String existingDiary,
+    String conversationHistory, {
+    String additionalContext = '',
+  }) {
     final extra = additionalContext.isNotEmpty
         ? '\n\n【参考情報（日記に自然に織り込むこと）】\n$additionalContext'
         : '';
@@ -31,24 +35,10 @@ class DiaryPrompts {
   // entries は (YYYY-MM-DD, データMap) のリストで、日付昇順でも降順でも可。
   // 内部で日付昇順に整形し直し、日記本文と主要回答だけを抜き出して渡す。
   static String buildAnalysisPrompt(
-      List<MapEntry<String, Map<String, dynamic>>> entries) {
+    List<MapEntry<String, Map<String, dynamic>>> entries,
+  ) {
     final sorted = [...entries]..sort((a, b) => a.key.compareTo(b.key));
-    final body = sorted.map((e) {
-      final data = e.value;
-      final diary = (data['diary'] as String?)?.trim();
-      final answers = data['answers'] as Map<String, dynamic>?;
-      final numeric = data['numericAnswers'] as Map<String, dynamic>?;
-
-      final parts = <String>['【${e.key}】'];
-      if (diary != null && diary.isNotEmpty) {
-        parts.add('日記: $diary');
-      }
-      final answerLine = _formatAnswers(answers, numeric);
-      if (answerLine.isNotEmpty) {
-        parts.add('回答: $answerLine');
-      }
-      return parts.join('\n');
-    }).join('\n\n');
+    final body = _formatEntries(sorted); // ← 切り出したメソッドを呼ぶ
 
     return '以下は依頼人の直近${sorted.length}日分の事件簿である。\n\n'
         '$body\n\n'
@@ -60,8 +50,30 @@ class DiaryPrompts {
         '■励まし（光っている取り組みへの一言）';
   }
 
+  // 複数エントリを「【日付】日記: ... / 回答: ...」形式の文字列に整形する
+  static String _formatEntries(
+    List<MapEntry<String, Map<String, dynamic>>> entries,
+  ) {
+    return entries
+        .map((e) {
+          final data = e.value;
+          final diary = (data['diary'] as String?)?.trim();
+          final answers = data['answers'] as Map<String, dynamic>?;
+          final numeric = data['numericAnswers'] as Map<String, dynamic>?;
+
+          final parts = <String>['【${e.key}】'];
+          if (diary != null && diary.isNotEmpty) parts.add('日記: $diary');
+          final answerLine = _formatAnswers(answers, numeric);
+          if (answerLine.isNotEmpty) parts.add('回答: $answerLine');
+          return parts.join('\n');
+        })
+        .join('\n\n');
+  }
+
   static String _formatAnswers(
-      Map<String, dynamic>? answers, Map<String, dynamic>? numeric) {
+    Map<String, dynamic>? answers,
+    Map<String, dynamic>? numeric,
+  ) {
     if (answers == null && numeric == null) return '';
     final pairs = <String>[];
     final sleep = numeric?['sleep'];
@@ -70,6 +82,7 @@ class DiaryPrompts {
       final v = answers?[key];
       if (v is String && v.isNotEmpty) pairs.add('$label:$v');
     }
+
     add('food', '食事');
     add('exercise', '運動');
     add('study', '勉強');
@@ -77,5 +90,37 @@ class DiaryPrompts {
     add('event_how', '感情');
     add('event_where', '場所');
     return pairs.join(' / ');
+  }
+
+  // 今日1日のエントリと直近14日分を渡して、今日へのコメントプロンプトを組み立てる。
+  static String buildDailyCommentPrompt(
+    Map<String, dynamic> todayEntry,
+    List<MapEntry<String, Map<String, dynamic>>> recentEntries,
+  ) {
+    // 今日のデータを整形
+    final diary = (todayEntry['diary'] as String?)?.trim();
+    final answers = todayEntry['answers'] as Map<String, dynamic>?;
+    final numeric = todayEntry['numericAnswers'] as Map<String, dynamic>?;
+
+    final todayParts = <String>[];
+    if (diary != null && diary.isNotEmpty) todayParts.add('日記: $diary');
+    final answerLine = _formatAnswers(answers, numeric);
+    if (answerLine.isNotEmpty) todayParts.add('回答: $answerLine');
+    final todayBody = todayParts.join('\n');
+
+    // 直近14日分を整形
+    final sorted = [...recentEntries]..sort((a, b) => a.key.compareTo(b.key));
+    final recentBody = _formatEntries(sorted);
+
+    return '以下は依頼人の今日の記録である。\n\n'
+        '$todayBody\n\n'
+        '以下は依頼人の直近${sorted.length}日分の事件簿である（比較参考用）。\n\n'
+        '$recentBody\n\n'
+        '【依頼内容】\n'
+        '今日の記録を読み、以下3節でコメントをまとめてください。各節は1〜2文、'
+        '全体で200字以内に収めること。見出しは出力に含めること。\n'
+        '■今日の要約\n'
+        '■気になった点（直近の傾向との違い・変化）\n'
+        '■探偵からの一言';
   }
 }

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -58,7 +58,12 @@ class FirestoreService {
 
   // 会話の1メッセージをFirestoreに保存する（順序orderで並び替えできるようにする）
   Future<void> saveMessage(
-      String uid, String date, String role, String text, int order) async {
+    String uid,
+    String date,
+    String role,
+    String text,
+    int order,
+  ) async {
     await _db
         .collection('users')
         .doc(uid)
@@ -66,18 +71,21 @@ class FirestoreService {
         .doc(date)
         .collection('conversation')
         .add({
-      'role': role,
-      'text': text,
-      'order': order,
-      'timestamp': FieldValue.serverTimestamp(),
-    });
+          'role': role,
+          'text': text,
+          'order': order,
+          'timestamp': FieldValue.serverTimestamp(),
+        });
   }
 
   // 質問キー→回答テキストのマップをFirestoreに保存する（既存データとマージする）
   // numericAnswers が渡された場合は数値データも同時に保存する
   Future<void> saveAnswers(
-      String uid, String date, Map<String, String> answers,
-      {Map<String, double>? numericAnswers}) async {
+    String uid,
+    String date,
+    Map<String, String> answers, {
+    Map<String, double>? numericAnswers,
+  }) async {
     if (answers.isEmpty && (numericAnswers == null || numericAnswers.isEmpty)) {
       return;
     }
@@ -96,7 +104,9 @@ class FirestoreService {
 
   // 直近 days 日分のエントリを日付文字列とデータのペアで返す
   Future<List<MapEntry<String, Map<String, dynamic>>>> getRecentEntries(
-      String uid, int days) async {
+    String uid,
+    int days,
+  ) async {
     final now = DateTime.now();
     final from = now.subtract(Duration(days: days - 1));
     final fromStr = from.toIso8601String().split('T')[0];
@@ -115,12 +125,7 @@ class FirestoreService {
 
   // 生成した日記テキストをFirestoreに保存する（既存データとマージする）
   Future<void> saveDiary(String uid, String date, String diary) async {
-    await _db
-        .collection('users')
-        .doc(uid)
-        .collection('entries')
-        .doc(date)
-        .set({
+    await _db.collection('users').doc(uid).collection('entries').doc(date).set({
       'diary': diary,
       'timestamp': FieldValue.serverTimestamp(),
     }, SetOptions(merge: true));
@@ -141,10 +146,7 @@ class FirestoreService {
       recordFood: true,
       recordExercise: true,
       recordStudy: true,
-      customQuestions: [
-        '今日、心が動く瞬間はあった？',
-        '今日、初めて・新しく挑戦したことは？',
-      ],
+      customQuestions: ['今日、心が動く瞬間はあった？', '今日、初めて・新しく挑戦したことは？'],
       selectedRole: 'hardboiled',
     );
     await saveUserSettings(uid, demoSettings);
@@ -152,7 +154,8 @@ class FirestoreService {
     // 古い順（13日前→今日）に並べたエントリ列。doc IDは投入時に動的生成する。
     final entries = <Map<String, dynamic>>[
       {
-        'diary': '七時間の睡眠で一日が明けた。午前を洗濯と部屋の片付けに充てた依頼人は、昼下がり、近所のカフェにいた。読書の手を止め、ふと思い立って注文をすべて英語で通したという。店員はごく自然に応じ、拍子抜けするほど呆気なく事は済んだ。本人は「面白かった」とだけ漏らしている。夜は友人とのオンラインゲーム。体も頭も程よく動かした一日だったことが確認された。',
+        'diary':
+            '七時間の睡眠で一日が明けた。午前を洗濯と部屋の片付けに充てた依頼人は、昼下がり、近所のカフェにいた。読書の手を止め、ふと思い立って注文をすべて英語で通したという。店員はごく自然に応じ、拍子抜けするほど呆気なく事は済んだ。本人は「面白かった」とだけ漏らしている。夜は友人とのオンラインゲーム。体も頭も程よく動かした一日だったことが確認された。',
         'answers': {
           'sleep': '7時間',
           'food': 'カフェのパスタ',
@@ -172,7 +175,8 @@ class FirestoreService {
         'numericAnswers': {'sleep': 7.0},
       },
       {
-        'diary': '六時間の睡眠。午前は統計学と線形代数の講義で埋まっていた。昼、依頼人は学内の図書館へ向かう。初めて自習室を予約し、その一室にこもったという。静寂が思考を運び、停滞していたレポートは一気に最後まで書き上がった。本人は「集中できた」と手応えを語っている。夕食を済ませると糸が切れたように眠りに落ちたことが記録されている。短い夜だったが、机の上の達成は確かだ。',
+        'diary':
+            '六時間の睡眠。午前は統計学と線形代数の講義で埋まっていた。昼、依頼人は学内の図書館へ向かう。初めて自習室を予約し、その一室にこもったという。静寂が思考を運び、停滞していたレポートは一気に最後まで書き上がった。本人は「集中できた」と手応えを語っている。夕食を済ませると糸が切れたように眠りに落ちたことが記録されている。短い夜だったが、机の上の達成は確かだ。',
         'answers': {
           'sleep': '6時間',
           'food': '学食のカレー',
@@ -192,7 +196,8 @@ class FirestoreService {
         'numericAnswers': {'sleep': 6.0},
       },
       {
-        'diary': '午前のプログラミング演習を終え、依頼人は研究室にこもった。午後いっぱいを費やした相手は、pandasのgroupbyに潜む一つのバグ。ドキュメントを丹念に読み返すうち、原因はようやく姿を現したという。長く追い続けた糸口がほどけた瞬間、本人は「すっきりした」と短く息を吐いた。夜はジムでランニングとストレッチ。自炊の鶏むね肉で締めた一日は、頭も体も使い切ったことが確認された。睡眠は七時間。',
+        'diary':
+            '午前のプログラミング演習を終え、依頼人は研究室にこもった。午後いっぱいを費やした相手は、pandasのgroupbyに潜む一つのバグ。ドキュメントを丹念に読み返すうち、原因はようやく姿を現したという。長く追い続けた糸口がほどけた瞬間、本人は「すっきりした」と短く息を吐いた。夜はジムでランニングとストレッチ。自炊の鶏むね肉で締めた一日は、頭も体も使い切ったことが確認された。睡眠は七時間。',
         'answers': {
           'sleep': '7時間',
           'food': '鶏むね肉の照り焼き（自炊）',
@@ -212,7 +217,8 @@ class FirestoreService {
         'numericAnswers': {'sleep': 7.0},
       },
       {
-        'diary': '睡眠は五時間と短い。午前は機械学習入門のオンライン講義に充て、午後は近所を三十分歩いてから昼寝で体を整えたという。夜、依頼人は友人に誘われ居酒屋の席に着いた。長らく苦手としてきたレバーが運ばれてくる。意を決して口に運ぶと、不思議と箸が止まらず、ついには完食。本人も「自分でも驚いた」と面白がっている。唐揚げと枝豆を囲んだ賑やかな夜だったことが記録されている。',
+        'diary':
+            '睡眠は五時間と短い。午前は機械学習入門のオンライン講義に充て、午後は近所を三十分歩いてから昼寝で体を整えたという。夜、依頼人は友人に誘われ居酒屋の席に着いた。長らく苦手としてきたレバーが運ばれてくる。意を決して口に運ぶと、不思議と箸が止まらず、ついには完食。本人も「自分でも驚いた」と面白がっている。唐揚げと枝豆を囲んだ賑やかな夜だったことが記録されている。',
         'answers': {
           'sleep': '5時間',
           'food': '居酒屋',
@@ -232,7 +238,8 @@ class FirestoreService {
         'numericAnswers': {'sleep': 5.0},
       },
       {
-        'diary': '八時間の睡眠が、この日の冴えを支えていたのかもしれない。午前は英語とデータ構造の講義。その流れのまま、午後の図書館で依頼人は試験勉強に没頭した。ふと、習ったばかりのヒープを何も見ずに一から書き起こしてみたという。手は驚くほど滑らかに動き、コードは淀みなく組み上がった。「自信がついた」と本人は手応えを口にしている。帰宅後は入浴と読書で静かに一日を閉じたことが確認された。',
+        'diary':
+            '八時間の睡眠が、この日の冴えを支えていたのかもしれない。午前は英語とデータ構造の講義。その流れのまま、午後の図書館で依頼人は試験勉強に没頭した。ふと、習ったばかりのヒープを何も見ずに一から書き起こしてみたという。手は驚くほど滑らかに動き、コードは淀みなく組み上がった。「自信がついた」と本人は手応えを口にしている。帰宅後は入浴と読書で静かに一日を閉じたことが確認された。',
         'answers': {
           'sleep': '8時間',
           'food': '日替わり定食',
@@ -252,7 +259,8 @@ class FirestoreService {
         'numericAnswers': {'sleep': 8.0},
       },
       {
-        'diary': '六時間の睡眠で迎えた朝は、確率論の講義と小テストから始まった。午後四時、依頼人はカフェの制服に袖を通す。閉店までの五時間、いつもは言葉少なに皿を運ぶだけの本人が、この日は常連客へ自ら声をかけたという。新メニューの感想を尋ねると、相手は思いのほか饒舌に語ってくれた。「聞いてよかった」と本人は嬉しげだ。まかないのカレーで腹を満たし、帰宅後はシャワーを浴びて床に就いたことが記録されている。',
+        'diary':
+            '六時間の睡眠で迎えた朝は、確率論の講義と小テストから始まった。午後四時、依頼人はカフェの制服に袖を通す。閉店までの五時間、いつもは言葉少なに皿を運ぶだけの本人が、この日は常連客へ自ら声をかけたという。新メニューの感想を尋ねると、相手は思いのほか饒舌に語ってくれた。「聞いてよかった」と本人は嬉しげだ。まかないのカレーで腹を満たし、帰宅後はシャワーを浴びて床に就いたことが記録されている。',
         'answers': {
           'sleep': '6時間',
           'food': 'アルバイト先でまかない（カレー）',
@@ -272,7 +280,8 @@ class FirestoreService {
         'numericAnswers': {'sleep': 6.0},
       },
       {
-        'diary': '九時間。たっぷりの睡眠から始まった休日だった。午前はYoutubeを横目にストレッチで体をほぐし、ホットケーキで遅い朝食を取ったという。午後からはハッカソンの開発に没頭。FlutterにGemini APIをつなぎ込む作業が、夜になってついに実を結んだ。画面の向こうでAIが初めて返答を寄こした瞬間、依頼人は「感動した」と声を弾ませている。デリバリーのピザで祝杯をあげ、レビューの準備まで手をつけたことが確認された。',
+        'diary':
+            '九時間。たっぷりの睡眠から始まった休日だった。午前はYoutubeを横目にストレッチで体をほぐし、ホットケーキで遅い朝食を取ったという。午後からはハッカソンの開発に没頭。FlutterにGemini APIをつなぎ込む作業が、夜になってついに実を結んだ。画面の向こうでAIが初めて返答を寄こした瞬間、依頼人は「感動した」と声を弾ませている。デリバリーのピザで祝杯をあげ、レビューの準備まで手をつけたことが確認された。',
         'answers': {
           'sleep': '9時間',
           'food': 'デリバリーのピザ',
@@ -292,7 +301,8 @@ class FirestoreService {
         'numericAnswers': {'sleep': 9.0},
       },
       {
-        'diary': '夜明け前、まだ街が眠るうちに依頼人は布団を抜け出した。七時間の睡眠で目覚めは軽い。向かった先は近所の公園。これまで縁のなかった早朝のランニングに、思い切って足を踏み出したという。澄んだ空気と人気のない並木道は、想像していたよりずっと心地よかったらしい。「面白かった」と本人は息を弾ませている。午後はアルゴリズムの講義に出席し、鮭の塩焼きで夕食を済ませると、いつもより早く床に就いたことが記録されている。',
+        'diary':
+            '夜明け前、まだ街が眠るうちに依頼人は布団を抜け出した。七時間の睡眠で目覚めは軽い。向かった先は近所の公園。これまで縁のなかった早朝のランニングに、思い切って足を踏み出したという。澄んだ空気と人気のない並木道は、想像していたよりずっと心地よかったらしい。「面白かった」と本人は息を弾ませている。午後はアルゴリズムの講義に出席し、鮭の塩焼きで夕食を済ませると、いつもより早く床に就いたことが記録されている。',
         'answers': {
           'sleep': '7時間',
           'food': '鮭の塩焼き（自炊）',
@@ -312,7 +322,8 @@ class FirestoreService {
         'numericAnswers': {'sleep': 7.0},
       },
       {
-        'diary': '六時間の睡眠。午前から依頼人はスライドの最終確認に余念がなかった。迎えた午後、研究室の輪講。初めて発表者の側に立った本人は、用意してきた論文の要点を一つずつ言葉にしていったという。質疑にも詰まることなく応じ、終えたときには大役を果たした実感が残った。「やりきった」と本人は晴れやかだ。夜は友人との通話でささやかな打ち上げ。張り詰めた一日を、笑い声で締めくくったことが確認された。',
+        'diary':
+            '六時間の睡眠。午前から依頼人はスライドの最終確認に余念がなかった。迎えた午後、研究室の輪講。初めて発表者の側に立った本人は、用意してきた論文の要点を一つずつ言葉にしていったという。質疑にも詰まることなく応じ、終えたときには大役を果たした実感が残った。「やりきった」と本人は晴れやかだ。夜は友人との通話でささやかな打ち上げ。張り詰めた一日を、笑い声で締めくくったことが確認された。',
         'answers': {
           'sleep': '6時間',
           'food': '学食の定食',
@@ -332,7 +343,8 @@ class FirestoreService {
         'numericAnswers': {'sleep': 6.0},
       },
       {
-        'diary': '七時間の睡眠で迎えた一日は、微分積分の講義から動き出した。午後は課題と読書に費やし、帰路、依頼人はふと路地裏の古本屋に立ち寄ったという。棚を端から目で追っていた指が、一冊で止まる。長く探し続けていた絶版の数学書が、そこに静かに収まっていた。「まさかここで」と本人は声を漏らしている。思わぬ巡り合わせを抱えて家路についた夜だった。よく歩き、よく学んだ一日だったことが記録されている。',
+        'diary':
+            '七時間の睡眠で迎えた一日は、微分積分の講義から動き出した。午後は課題と読書に費やし、帰路、依頼人はふと路地裏の古本屋に立ち寄ったという。棚を端から目で追っていた指が、一冊で止まる。長く探し続けていた絶版の数学書が、そこに静かに収まっていた。「まさかここで」と本人は声を漏らしている。思わぬ巡り合わせを抱えて家路についた夜だった。よく歩き、よく学んだ一日だったことが記録されている。',
         'answers': {
           'sleep': '7時間',
           'food': 'カフェのサンドイッチ',
@@ -352,7 +364,8 @@ class FirestoreService {
         'numericAnswers': {'sleep': 7.0},
       },
       {
-        'diary': '終日の雨。八時間眠った依頼人は、雨音を聞きながらの二度寝という贅沢から一日を始めたという。午後は録りためた番組をゆっくりと消化。これといった予定のない、静かな休日だった。夜になり、本人はかねて気になっていたスパイスからのカレー作りに腰を据える。慣れない計量と火加減に手こずりながらも、台所には次第に本格的な香りが立ち込めていった。「面白かった」と本人。雨の一日を、湯気の向こうで締めくくったことが確認された。',
+        'diary':
+            '終日の雨。八時間眠った依頼人は、雨音を聞きながらの二度寝という贅沢から一日を始めたという。午後は録りためた番組をゆっくりと消化。これといった予定のない、静かな休日だった。夜になり、本人はかねて気になっていたスパイスからのカレー作りに腰を据える。慣れない計量と火加減に手こずりながらも、台所には次第に本格的な香りが立ち込めていった。「面白かった」と本人。雨の一日を、湯気の向こうで締めくくったことが確認された。',
         'answers': {
           'sleep': '8時間',
           'food': 'スパイスから作ったカレー',
@@ -372,7 +385,8 @@ class FirestoreService {
         'numericAnswers': {'sleep': 8.0},
       },
       {
-        'diary': '六時間の睡眠で始まった一日は、線形代数の講義と図書館での予習で過ぎていった。夜、依頼人はアルバイト先のカフェに立つ。閉店後、店長から初めてレジ締めを任されたという。売上を数え、帳簿と突き合わせる一連の作業を、同僚に教わりながら最後までやり遂げた。数字がぴたりと合ったとき、信頼されている手応えが胸に残ったらしい。「任せてもらえて嬉しかった」と本人。まかないで腹を満たし、夜道を帰っていったことが記録されている。',
+        'diary':
+            '六時間の睡眠で始まった一日は、線形代数の講義と図書館での予習で過ぎていった。夜、依頼人はアルバイト先のカフェに立つ。閉店後、店長から初めてレジ締めを任されたという。売上を数え、帳簿と突き合わせる一連の作業を、同僚に教わりながら最後までやり遂げた。数字がぴたりと合ったとき、信頼されている手応えが胸に残ったらしい。「任せてもらえて嬉しかった」と本人。まかないで腹を満たし、夜道を帰っていったことが記録されている。',
         'answers': {
           'sleep': '6時間',
           'food': 'アルバイト先のまかない',
@@ -392,7 +406,8 @@ class FirestoreService {
         'numericAnswers': {'sleep': 6.0},
       },
       {
-        'diary': '五時間の睡眠で迎えた朝、確率統計の講義までは穏やかに進んでいた。事は午後に起きる。作りかけていたプレゼン資料が、保存の手違いで消えていたという。依頼人は気を取り直し、記憶を頼りに一から組み直す作業へ取りかかった。手は止めず、夕方までに資料はかつての形を取り戻していった。夜には同じことを繰り返さぬよう、クラウドへの自動バックアップを設定したと本人は語っている。教訓を一つ手にした一日だったことが記録されている。',
+        'diary':
+            '五時間の睡眠で迎えた朝、確率統計の講義までは穏やかに進んでいた。事は午後に起きる。作りかけていたプレゼン資料が、保存の手違いで消えていたという。依頼人は気を取り直し、記憶を頼りに一から組み直す作業へ取りかかった。手は止めず、夕方までに資料はかつての形を取り戻していった。夜には同じことを繰り返さぬよう、クラウドへの自動バックアップを設定したと本人は語っている。教訓を一つ手にした一日だったことが記録されている。',
         'answers': {
           'sleep': '5時間',
           'food': '学食のカレー',
@@ -412,7 +427,8 @@ class FirestoreService {
         'numericAnswers': {'sleep': 5.0},
       },
       {
-        'diary': '九時間眠ってもなお、体はまだ本調子ではなかったらしい。喉に違和感を覚えた依頼人は、この日の予定をすべて切り上げ、休養に充てると決めたという。午前はおかゆで胃を温め、午後は録りためていた映画をゆっくりと観て過ごした。動き回らず、ただ体の声に耳を澄ませる一日。夜は早々に床へ入っている。立ち止まることもまた、明日へ向けた支度なのだろう。無理をしなかった一日として記録されている。',
+        'diary':
+            '九時間眠ってもなお、体はまだ本調子ではなかったらしい。喉に違和感を覚えた依頼人は、この日の予定をすべて切り上げ、休養に充てると決めたという。午前はおかゆで胃を温め、午後は録りためていた映画をゆっくりと観て過ごした。動き回らず、ただ体の声に耳を澄ませる一日。夜は早々に床へ入っている。立ち止まることもまた、明日へ向けた支度なのだろう。無理をしなかった一日として記録されている。',
         'answers': {
           'sleep': '9時間',
           'food': 'おかゆ',
@@ -445,24 +461,26 @@ class FirestoreService {
           .collection('entries')
           .doc(dateStr)
           .set({
-        'diary': entry['diary'],
-        'answers': entry['answers'],
-        'numericAnswers': entry['numericAnswers'],
-        'timestamp': FieldValue.serverTimestamp(),
-      });
+            'diary': entry['diary'],
+            'answers': entry['answers'],
+            'numericAnswers': entry['numericAnswers'],
+            'timestamp': FieldValue.serverTimestamp(),
+          });
     }
   }
 
   // 全エントリを日付の降順で返す（CSVエクスポート用）
   Future<List<MapEntry<String, Map<String, dynamic>>>> getAllEntries(
-      String uid) async {
+    String uid,
+  ) async {
     final snap = await _db
         .collection('users')
         .doc(uid)
         .collection('entries')
         .get();
-    final entries =
-        snap.docs.map((doc) => MapEntry(doc.id, doc.data())).toList();
+    final entries = snap.docs
+        .map((doc) => MapEntry(doc.id, doc.data()))
+        .toList();
     entries.sort((a, b) => b.key.compareTo(a.key));
     return entries;
   }
@@ -470,10 +488,7 @@ class FirestoreService {
   // 日記エントリ一覧を取得するクエリを返す
   // ソートはクライアント側でドキュメントID（YYYY-MM-DD）の降順で行う
   Query<Map<String, dynamic>> entriesQuery(String uid) {
-    return _db
-        .collection('users')
-        .doc(uid)
-        .collection('entries');
+    return _db.collection('users').doc(uid).collection('entries');
   }
 
   // 最新のAI所見キャッシュを取得する（未生成なら null を返す）
@@ -497,9 +512,31 @@ class FirestoreService {
         .collection('analyses')
         .doc('latest')
         .set({
-      'text': text,
-      'periodDays': 14,
-      'generatedAt': FieldValue.serverTimestamp(),
-    });
+          'text': text,
+          'periodDays': 14,
+          'generatedAt': FieldValue.serverTimestamp(),
+        });
+  }
+
+  // 今日のAIコメントキャッシュを取得する（未生成なら null を返す）
+  Future<Map<String, dynamic>?> getTodayComment(String uid) async {
+    final doc = await _db
+        .collection('users')
+        .doc(uid)
+        .collection('analyses')
+        .doc('today')
+        .get();
+    if (doc.exists) return doc.data();
+    return null;
+  }
+
+  // 今日のAIコメントを analyses/today に上書き保存する
+  Future<void> saveTodayComment(String uid, String text) async {
+    await _db
+        .collection('users')
+        .doc(uid)
+        .collection('analyses')
+        .doc('today')
+        .set({'text': text, 'generatedAt': FieldValue.serverTimestamp()});
   }
 }

--- a/lib/services/gemini_service.dart
+++ b/lib/services/gemini_service.dart
@@ -19,56 +19,54 @@ class GeminiService {
   final String _role;
 
   GeminiService(String apiKey, String role)
-      : _role = role,
-        _interviewModel = GenerativeModel(
-          model: 'gemini-2.5-flash',
-          apiKey: apiKey,
-          systemInstruction:
-              Content.system(roleFor(role).interviewerInstruction),
-          // 構造化出力: {sufficient: bool, question: string} を強制し、
-          // 「DONE」文字列マッチによる脆い終了判定を廃止する
-          generationConfig: GenerationConfig(
-            responseMimeType: 'application/json',
-            responseSchema: Schema.object(
-              properties: {
-                'sufficient': Schema.boolean(
-                  description: '証言が十分に語られているかどうか',
-                ),
-                'question': Schema.string(
-                  description:
-                      'sufficient が false の場合の深掘り質問。true の場合は空文字でよい',
-                ),
-              },
-              requiredProperties: ['sufficient', 'question'],
-            ),
+    : _role = role,
+      _interviewModel = GenerativeModel(
+        model: 'gemini-2.5-flash',
+        apiKey: apiKey,
+        systemInstruction: Content.system(roleFor(role).interviewerInstruction),
+        // 構造化出力: {sufficient: bool, question: string} を強制し、
+        // 「DONE」文字列マッチによる脆い終了判定を廃止する
+        generationConfig: GenerationConfig(
+          responseMimeType: 'application/json',
+          responseSchema: Schema.object(
+            properties: {
+              'sufficient': Schema.boolean(description: '証言が十分に語られているかどうか'),
+              'question': Schema.string(
+                description: 'sufficient が false の場合の深掘り質問。true の場合は空文字でよい',
+              ),
+            },
+            requiredProperties: ['sufficient', 'question'],
           ),
         ),
-        _diaryModel = GenerativeModel(
-          model: 'gemini-2.5-flash',
-          apiKey: apiKey,
-          systemInstruction: Content.system(
-              AiInstructions.diaryWriter(roleFor(role).diaryStyle)),
+      ),
+      _diaryModel = GenerativeModel(
+        model: 'gemini-2.5-flash',
+        apiKey: apiKey,
+        systemInstruction: Content.system(
+          AiInstructions.diaryWriter(roleFor(role).diaryStyle),
         ),
-        _analysisModel = GenerativeModel(
-          model: 'gemini-2.5-flash',
-          apiKey: apiKey,
-          systemInstruction: Content.system(
-              AiInstructions.analyst(roleFor(role).analystStyle)),
+      ),
+      _analysisModel = GenerativeModel(
+        model: 'gemini-2.5-flash',
+        apiKey: apiKey,
+        systemInstruction: Content.system(
+          AiInstructions.analyst(roleFor(role).analystStyle),
         ),
-        // インタビュアーと同じ人格指示だが、JSON構造化はせずプレーンテキストで相槌を返す
-        _reactionModel = GenerativeModel(
-          model: 'gemini-2.5-flash',
-          apiKey: apiKey,
-          systemInstruction:
-              Content.system(roleFor(role).interviewerInstruction),
-        );
+      ),
+      // インタビュアーと同じ人格指示だが、JSON構造化はせずプレーンテキストで相槌を返す
+      _reactionModel = GenerativeModel(
+        model: 'gemini-2.5-flash',
+        apiKey: apiKey,
+        systemInstruction: Content.system(roleFor(role).interviewerInstruction),
+      );
 
   // 会話履歴を渡して深掘り質問をGeminiに生成させる。
   // followUpHint を隠し指示として会話履歴に付加し、UIには表示しない。
   // 戻り値の sufficient が true の場合、これ以上の深掘りは不要（呼び出し側で打ち切る）。
   // JSONパースに失敗した場合は安全側に倒し、sufficient:true として扱う。
   Future<({bool sufficient, String question})> generateFollowUp(
-      List<Map<String, String>> messages) async {
+    List<Map<String, String>> messages,
+  ) async {
     final history = _buildHistory(messages);
     final prompt =
         '${AiInstructions.followUpHint(roleFor(_role).interviewerInstruction)}\n\n以下が依頼人の証言です：\n$history';
@@ -110,36 +108,41 @@ class GeminiService {
 
   // 会話履歴から日記テキストをGeminiに生成させる。
   // additionalContext: カスタム質問・思い出しアシストの回答など、追加で含めるコンテキスト
-  Future<String> generateDiary(List<Map<String, String>> messages,
-      {String additionalContext = ''}) async {
+  Future<String> generateDiary(
+    List<Map<String, String>> messages, {
+    String additionalContext = '',
+  }) async {
     final history = _buildHistory(messages);
-    final prompt = DiaryPrompts.buildDiaryPrompt(history,
-        additionalContext: additionalContext);
-    final response = await _diaryModel.generateContent([
-      Content.text(prompt),
-    ]);
+    final prompt = DiaryPrompts.buildDiaryPrompt(
+      history,
+      additionalContext: additionalContext,
+    );
+    final response = await _diaryModel.generateContent([Content.text(prompt)]);
     return response.text?.trim() ?? '日記を生成できませんでした。';
   }
 
   // 既存の日記と追記インタビューの会話を統合して日記テキストをGeminiに生成させる
   // additionalContext: カスタム質問・思い出しアシストの回答など、追加で含めるコンテキスト
   Future<String> generateDiaryWithExisting(
-      String existingDiary, List<Map<String, String>> messages,
-      {String additionalContext = ''}) async {
+    String existingDiary,
+    List<Map<String, String>> messages, {
+    String additionalContext = '',
+  }) async {
     final history = _buildHistory(messages);
     final prompt = DiaryPrompts.buildDiaryWithExistingPrompt(
-        existingDiary, history,
-        additionalContext: additionalContext);
-    final response = await _diaryModel.generateContent([
-      Content.text(prompt),
-    ]);
+      existingDiary,
+      history,
+      additionalContext: additionalContext,
+    );
+    final response = await _diaryModel.generateContent([Content.text(prompt)]);
     return response.text?.trim() ?? '日記を生成できませんでした。';
   }
 
   // 直近のエントリ群（日付→データ）から所見テキストをGeminiに生成させる。
   // 呼び出し側は FirestoreService.getRecentEntries の戻り値をそのまま渡せる。
   Future<String> generateAnalysis(
-      List<MapEntry<String, Map<String, dynamic>>> entries) async {
+    List<MapEntry<String, Map<String, dynamic>>> entries,
+  ) async {
     final prompt = DiaryPrompts.buildAnalysisPrompt(entries);
     final response = await _analysisModel.generateContent([
       Content.text(prompt),
@@ -150,8 +153,22 @@ class GeminiService {
   // メッセージリストを「探偵: ...」「依頼人: ...」形式の文字列に変換する
   String _buildHistory(List<Map<String, String>> messages) {
     return messages
-        .map((m) =>
-            '${m['role'] == 'ai' ? '探偵' : '依頼人'}: ${m['text']}')
+        .map((m) => '${m['role'] == 'ai' ? '探偵' : '依頼人'}: ${m['text']}')
         .join('\n');
+  }
+
+  // 今日のエントリと直近14日分からコメントテキストをGeminiに生成させる。
+  Future<String> generateDailyComment(
+    Map<String, dynamic> todayEntry,
+    List<MapEntry<String, Map<String, dynamic>>> recentEntries,
+  ) async {
+    final prompt = DiaryPrompts.buildDailyCommentPrompt(
+      todayEntry,
+      recentEntries,
+    );
+    final response = await _analysisModel.generateContent([
+      Content.text(prompt),
+    ]);
+    return response.text?.trim() ?? 'コメントを生成できませんでした。';
   }
 }


### PR DESCRIPTION
## 概要
証拠分析室（`analytics_page.dart`）に「今日の行動」セクションを追加した。既存の「探偵の所見（直近14日）」はそのまま残し、新たに今日1日分のデータをGeminiに渡してコメントを生成する機能を実装した。

---

## 背景・設計判断

### なぜ既存の `generateAnalysis()` を流用しなかったか
既存の `buildAnalysisPrompt()` のプロンプト指示が「複数日のパターン・繰り返し・変化を読み取れ」という内容になっており、1日分のデータを渡した場合に指示とデータが噛み合わない。また出力フォーマットが3節（所見/兆候/励まし）固定で、今日へのひとことには重すぎるため、新規メソッドを作成した。

### なぜFirestoreの保存先を分けたか
14日分と今日分を `analyses/latest` に同居させると、どちらか一方を再生成したときにもう一方が上書きされて消えるため、`analyses/today` に別ドキュメントとして保存する設計にした。

### プロンプト設計
今日のコメントには「今日の要約」「以前との違い・変化」「探偵からの一言」の3節を設けた。変化を出すために今日1日分だけでなく直近14日分も参照用として渡している。`_entriesData` がすでに14日分を保持しているため、追加のFirestore呼び出しは不要。

### DRY対応
`buildAnalysisPrompt()` 内の複数エントリ整形処理を `_formatEntries()` として切り出し、`buildAnalysisPrompt()` と `buildDailyCommentPrompt()` の両方から使い回す形にした。

---

## 変更ファイル

### `lib/prompts/diary_prompts.dart`
- `_formatEntries()` を新規追加（複数エントリの整形処理をDRY化）
- `buildAnalysisPrompt()` を `_formatEntries()` を使う形にリファクタリング
- `buildDailyCommentPrompt(todayEntry, recentEntries)` を新規追加

### `lib/services/gemini_service.dart`
- `generateDailyComment(todayEntry, recentEntries)` を新規追加
- `_analysisModel` を使い回し（システム指示が「記録を読み返して所見を記す役」で共通のため）

### `lib/services/firestore_service.dart`
- `getTodayComment(uid)` を新規追加（`analyses/today` から取得）
- `saveTodayComment(uid, text)` を新規追加（`analyses/today` に保存）

### `lib/pages/analytics_page.dart`
- 状態変数 `_dailyAnalysisText` / `_dailyAnalysisGeneratedAt` / `_isGeneratingDailyAnalysis` を追加
- `_loadData()` に `getTodayComment()` の並行フェッチと `setState()` への反映を追加
- `_generateDailyAnalysis()` を新規追加
- `build()` に「今日の行動」セクション（`_SectionHeader` + `_AiInsightSection`）を追加（14日分の下、サマリーの上）

---

## データの流れ

```
Firestore
  └─ getRecentEntries(uid, 14)
          │
          ▼
    _entriesData（14日分）
          │
          ├─ [today] → todayEntry
          │
          ▼
    buildDailyCommentPrompt(todayEntry, recentEntries)
          │
          ▼
    Gemini API
          │
          ▼
    analyses/today に保存 → 画面に表示
```